### PR TITLE
Remove extra '/' in US flag image path.

### DIFF
--- a/layouts/partials/disclaimer.html
+++ b/layouts/partials/disclaimer.html
@@ -4,7 +4,7 @@
   <div class="usa-grid">
     <div class="usa-disclaimer-official">
       <div class="usa-disclaimer-official__img">
-        <img class="usa-flag_icon" alt="US flag signifying that this is a United States Federal Government website" src="{{ .Site.BaseURL }}/assets/img/us_flag_small.png">
+        <img class="usa-flag_icon" alt="US flag signifying that this is a United States Federal Government website" src="{{ .Site.BaseURL }}assets/img/us_flag_small.png">
       </div>
       <div class="usa-disclaimer-official__body">
         {{ $translation.micro_copy.disclaimer }}


### PR DESCRIPTION
This fixes the incorrect image path for displaying the disclaimer US flag by removing an extra slash in the image path. 