### PR TITLE
Center 404 grid

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -7,7 +7,7 @@
 
       <a class="usa-skipnav" href="#main-content">Skip main navigation</a>
 
-      <section class="grid-container.padding-x-0 page-inner" id="main-content">
+      <section class="grid-container page-inner" id="main-content">
         <div class="grid-row">
           <div lang="en" class="grid-col-6">
             <span class="usa-label">English</span>


### PR DESCRIPTION
This fixes a bug where the 404 page was off-center by removing ".padding-x-0" from the page grid so as to meet the new "grid-container" class in USWDS 2.0.
