### PR TITLE
Change register Spanish wording

### DIFF
--- a/data/translations/spanish/register.toml
+++ b/data/translations/spanish/register.toml
@@ -8,7 +8,7 @@ download_others = "Descargue el formulario en otros idiomas:"
 step_one_label = "Paso 1"
 step_one = "Llene su registro de votante."
 step_two_label = "Paso 2"
-step_two = "Enviélo por correo postal a la oficina electoral de su estado."
+step_two = "Envíelo por correo postal a la oficina electoral de su estado."
 step_three_label = "Paso 3"
 step_three = "¡Vote en las próximas elecciones!"
 


### PR DESCRIPTION
Change Enviélo to Envíelo in Spanish by-mail registration wording. 