### PR TITLE
 Replace external links for Spanish redirects

### DIFF
--- a/config/gulp/lang/spanish/state-names.json
+++ b/config/gulp/lang/spanish/state-names.json
@@ -1,226 +1,339 @@
 {
   "alabama" : {
     "file": "alabama",
-    "title": "Alabama"
+    "title": "Alabama",
+    "state_abbreviation": "al",
+    "external_link": ""
   },
   "alaska" : {
     "file": "alaska",
-    "title": "Alaska"
+    "title": "Alaska",
+    "state_abbreviation": "ak",
+    "external_link": ""
+
   },
   "american-samoa" : {
     "file": "samoa-americana",
-    "title": "Samoa Americana"
+    "title": "Samoa Americana",
+    "state_abbreviation": "as",
+    "external_link": ""
   },
   "arizona" : {
     "file": "arizona",
-    "title": "Arizona"
+    "title": "Arizona",
+    "state_abbreviation": "az",
+    "external_link": ""
   },
   "arkansas" : {
     "file": "arkansas",
-    "title": "Arkansas"
+    "title": "Arkansas",
+    "state_abbreviation": "ar",
+    "external_link": ""
   },
   "california" : {
     "file": "california",
-    "title": "California"
+    "title": "California",
+    "state_abbreviation": "ca",
+    "external_link": ""
   },
   "colorado" : {
     "file": "colorado",
-    "title": "Colorado"
+    "title": "Colorado",
+    "state_abbreviation": "co",
+    "external_link": ""
   },
   "connecticut" : {
     "file": "conecticut",
-    "title": "Connecticut"
+    "title": "Connecticut",
+    "state_abbreviation": "ct",
+    "external_link": ""
   },
   "delaware" : {
     "file": "delaware",
-    "title": "Delaware"
+    "title": "Delaware",
+    "state_abbreviation": "de",
+    "external_link": ""
   },
   "washington-dc" : {
     "file": "distrito-de-columbia",
-    "title": "Distrito de Columbia"
+    "title": "Distrito de Columbia",
+    "state_abbreviation": "dc",
+    "external_link": ""
   },
   "florida" : {
     "file": "florida",
-    "title": "Florida"
+    "title": "Florida",
+    "state_abbreviation": "fl",
+    "external_link": ""
   },
   "georgia" : {
     "file": "georgia",
-    "title": "Georgia"
+    "title": "Georgia",
+    "state_abbreviation": "ga",
+    "external_link": ""
   },
   "guam" : {
     "file": "guam",
-    "title": "Guam"
+    "title": "Guam",
+    "state_abbreviation": "gu",
+    "external_link": ""
   },
   "hawaii" : {
     "file": "hawai",
-    "title": "Hawai"
+    "title": "Hawai",
+    "state_abbreviation": "hi",
+    "external_link": ""
   },
   "idaho" : {
     "file": "idaho",
-    "title": "Idaho"
+    "title": "Idaho",
+    "state_abbreviation": "id",
+    "external_link": ""
   },
   "illinois" : {
     "file": "illinois",
-    "title": "Illinois"
+    "title": "Illinois",
+    "state_abbreviation": "il",
+    "external_link": ""
   },
   "indiana" : {
     "file": "indiana",
-    "title": "Indiana"
+    "title": "Indiana",
+    "state_abbreviation": "in",
+    "external_link": ""
   },
   "iowa" : {
     "file": "iowa",
-    "title": "Iowa"
+    "title": "Iowa",
+    "state_abbreviation": "ia",
+    "external_link": ""
   },
   "kansas" : {
     "file": "kansas",
-    "title": "Kansas"
+    "title": "Kansas",
+    "state_abbreviation": "ks",
+    "external_link": ""
   },
   "kentucky" : {
     "file": "kentucky",
-    "title": "Kentucky"
+    "title": "Kentucky",
+    "state_abbreviation": "ky",
+    "external_link": ""
   },
   "louisiana" : {
     "file": "luisiana",
-    "title": "Luisiana"
+    "title": "Luisiana",
+    "state_abbreviation": "la",
+    "external_link": ""
   },
   "maine" : {
     "file": "maine",
-    "title": "Maine"
+    "title": "Maine",
+    "state_abbreviation": "me",
+    "external_link": ""
   },
   "maryland" : {
     "file": "maryland",
-    "title": "Maryland"
+    "title": "Maryland",
+    "state_abbreviation": "md",
+    "external_link": ""
   },
   "massachusetts" : {
     "file": "massachusetts",
-    "title": "Massachusetts"
+    "title": "Massachusetts",
+    "state_abbreviation": "ma",
+    "external_link": ""
   },
   "michigan" : {
     "file": "michigan",
-    "title": "Michigan"
+    "title": "Michigan",
+    "state_abbreviation": "mi",
+    "external_link": ""
   },
   "minnesota" : {
     "file": "minnesota",
-    "title": "Minnesota"
+    "title": "Minnesota",
+    "state_abbreviation": "mn",
+    "external_link": ""
   },
   "mississippi" : {
     "file": "misisipi",
-    "title": "Misisipi"
+    "title": "Misisipi",
+    "state_abbreviation": "ms",
+    "external_link": ""
   },
   "missouri" : {
     "file": "misuri",
-    "title": "Misuri"
+    "title": "Misuri",
+    "state_abbreviation": "mo",
+    "external_link": ""
   },
   "montana" : {
     "file": "montana",
-    "title": "Montana"
+    "title": "Montana",
+    "state_abbreviation": "mt",
+    "external_link": ""
   },
   "nebraska" : {
     "file": "nebraska",
-    "title": "Nebraska"
+    "title": "Nebraska",
+    "state_abbreviation": "ne",
+    "external_link": ""
   },
   "nevada" : {
     "file": "nevada",
-    "title": "Nevada"
+    "title": "Nevada",
+    "state_abbreviation": "nv",
+    "external_link": ""
   },
   "new-hampshire" : {
     "file": "nuevo-hampshire",
-    "title": "Nuevo Hampshire"
+    "title": "Nuevo Hampshire",
+    "state_abbreviation": "nh",
+    "external_link": ""
   },
   "new-jersey" : {
     "file": "nueva-jersey",
-    "title": "Nueva Jersey"
+    "title": "Nueva Jersey",
+    "state_abbreviation": "nj",
+    "external_link": ""
   },
   "new-mexico" : {
     "file": "nuevo-mexico",
-    "title": "Nuevo México"
+    "title": "Nuevo México",
+    "state_abbreviation": "nm",
+    "external_link": ""
   },
   "new-york" : {
     "file": "nueva-york",
-    "title": "Nueva York"
+    "title": "Nueva York",
+    "state_abbreviation": "ny",
+    "external_link": ""
   },
   "north-carolina" : {
     "file": "carolina-del-norte",
-    "title": "Carolina del Norte"
+    "title": "Carolina del Norte",
+    "state_abbreviation": "nc",
+    "external_link": ""
   },
   "north-dakota" : {
     "file": "dakota-del-norte",
-    "title": "Dakota del Norte"
+    "title": "Dakota del Norte",
+    "state_abbreviation": "nd",
+    "external_link": ""
   },
   "northern-mariana-islands" : {
     "file": "islas-marianas-del-norte",
-    "title": "Islas Marianas del Norte"
+    "title": "Islas Marianas del Norte",
+    "state_abbreviation": "mp",
+    "external_link": ""
   },
   "ohio" : {
     "file": "ohio",
-    "title": "Ohio"
+    "title": "Ohio",
+    "state_abbreviation": "oh",
+    "external_link": ""
   },
   "oklahoma" : {
     "file": "oklahoma",
-    "title": "Oklahoma"
+    "title": "Oklahoma",
+    "state_abbreviation": "ok",
+    "external_link": ""
   },
   "oregon" : {
     "file": "oregon",
-    "title": "Oregón"
+    "title": "Oregón",
+    "state_abbreviation": "or",
+    "external_link": "test"
   },
   "pennsylvania" : {
     "file": "pensilvania",
-    "title": "Pensilvania"
+    "title": "Pensilvania",
+    "state_abbreviation": "pa",
+    "external_link": ""
   },
   "puerto-rico" : {
     "file": "puerto-rico",
-    "title": "Puerto Rico"
+    "title": "Puerto Rico",
+    "state_abbreviation": "pr",
+    "external_link": ""
   },
   "rhode-island" : {
     "file": "rhode-island",
-    "title": "Rhode Island"
+    "title": "Rhode Island",
+    "state_abbreviation": "ri",
+    "external_link": ""
   },
   "south-dakota": {
     "file": "dakota-del-sur",
-    "title": "Dakota del Sur"
+    "title": "Dakota del Sur",
+    "state_abbreviation": "sd",
+    "external_link": ""
   },
   "south-carolina" : {
     "file": "carolina-del-sur",
-    "title": "Carolina del Sur"
+    "title": "Carolina del Sur",
+    "state_abbreviation": "sc",
+    "external_link": ""
   },
   "tennessee": {
     "file": "tenesi",
-    "title": "Tennessee"
+    "title": "Tennessee",
+    "state_abbreviation": "tn",
+    "external_link": ""
   },
   "texas": {
     "file": "texas",
-    "title": "Texas"
+    "title": "Texas",
+    "state_abbreviation": "tx",
+    "external_link": ""
   },
   "us-virgin-islands" : {
     "file": "islas-virgenes-de-ee-uu",
-    "title": "Islas Vírgenes de EE. UU."
+    "title": "Islas Vírgenes de EE. UU.",
+    "state_abbreviation": "vi",
+    "external_link": ""
   },
   "utah" : {
     "file": "utah",
-    "title": "Utah"
+    "title": "Utah",
+    "state_abbreviation": "ut",
+    "external_link": ""
   },
   "vermont" : {
     "file": "vermont",
-    "title": "Vermont"
+    "title": "Vermont",
+    "state_abbreviation": "vt",
+    "external_link": ""
   },
   "virginia" : {
     "file": "virginia",
-    "title": "Virginia"
+    "title": "Virginia",
+    "state_abbreviation": "va",
+    "external_link": ""
   },
   "west-virginia" : {
     "file": "virginia-occidental",
-    "title": "Virginia Occidental"
+    "title": "Virginia Occidental",
+    "state_abbreviation": "wv",
+    "external_link": ""
   },
   "washington" : {
     "file": "washington",
-    "title": "Washington"
+    "title": "Washington",
+    "state_abbreviation": "wa",
+    "external_link": ""
   },
   "wisconsin" : {
     "file": "wisconsin",
-    "title": "Wisconsin"
+    "title": "Wisconsin",
+    "state_abbreviation": "wi",
+    "external_link": ""
   },
   "wyoming" : {
     "file": "wyoming",
-    "title": "Wyoming"
+    "title": "Wyoming",
+    "state_abbreviation": "wy",
+    "external_link": ""
   }
 }

--- a/config/gulp/lang/spanish/state-names.json
+++ b/config/gulp/lang/spanish/state-names.json
@@ -34,7 +34,7 @@
     "file": "california",
     "title": "California",
     "state_abbreviation": "ca",
-    "external_link": ""
+    "external_link": "https://registertovote.ca.gov/es/"
   },
   "colorado" : {
     "file": "colorado",

--- a/config/gulp/lang/spanish/state-names.json
+++ b/config/gulp/lang/spanish/state-names.json
@@ -3,337 +3,337 @@
     "file": "alabama",
     "title": "Alabama",
     "state_abbreviation": "al",
-    "external_link": ""
+    "external_link": "test"
   },
   "alaska" : {
     "file": "alaska",
     "title": "Alaska",
     "state_abbreviation": "ak",
-    "external_link": ""
+    "external_link": "test"
 
   },
   "american-samoa" : {
     "file": "samoa-americana",
     "title": "Samoa Americana",
     "state_abbreviation": "as",
-    "external_link": ""
+    "external_link": "test"
   },
   "arizona" : {
     "file": "arizona",
     "title": "Arizona",
     "state_abbreviation": "az",
-    "external_link": ""
+    "external_link": " "
   },
   "arkansas" : {
     "file": "arkansas",
     "title": "Arkansas",
     "state_abbreviation": "ar",
-    "external_link": ""
+    "external_link": " "
   },
   "california" : {
     "file": "california",
     "title": "California",
     "state_abbreviation": "ca",
-    "external_link": ""
+    "external_link": " "
   },
   "colorado" : {
     "file": "colorado",
     "title": "Colorado",
     "state_abbreviation": "co",
-    "external_link": ""
+    "external_link": " "
   },
   "connecticut" : {
     "file": "conecticut",
     "title": "Connecticut",
     "state_abbreviation": "ct",
-    "external_link": ""
+    "external_link": " "
   },
   "delaware" : {
     "file": "delaware",
     "title": "Delaware",
     "state_abbreviation": "de",
-    "external_link": ""
+    "external_link": " "
   },
   "washington-dc" : {
     "file": "distrito-de-columbia",
     "title": "Distrito de Columbia",
     "state_abbreviation": "dc",
-    "external_link": ""
+    "external_link": " "
   },
   "florida" : {
     "file": "florida",
     "title": "Florida",
     "state_abbreviation": "fl",
-    "external_link": ""
+    "external_link": " "
   },
   "georgia" : {
     "file": "georgia",
     "title": "Georgia",
     "state_abbreviation": "ga",
-    "external_link": ""
+    "external_link": " "
   },
   "guam" : {
     "file": "guam",
     "title": "Guam",
     "state_abbreviation": "gu",
-    "external_link": ""
+    "external_link": " "
   },
   "hawaii" : {
     "file": "hawai",
     "title": "Hawai",
     "state_abbreviation": "hi",
-    "external_link": ""
+    "external_link": " "
   },
   "idaho" : {
     "file": "idaho",
     "title": "Idaho",
     "state_abbreviation": "id",
-    "external_link": ""
+    "external_link": " "
   },
   "illinois" : {
     "file": "illinois",
     "title": "Illinois",
     "state_abbreviation": "il",
-    "external_link": ""
+    "external_link": " "
   },
   "indiana" : {
     "file": "indiana",
     "title": "Indiana",
     "state_abbreviation": "in",
-    "external_link": ""
+    "external_link": " "
   },
   "iowa" : {
     "file": "iowa",
     "title": "Iowa",
     "state_abbreviation": "ia",
-    "external_link": ""
+    "external_link": " "
   },
   "kansas" : {
     "file": "kansas",
     "title": "Kansas",
     "state_abbreviation": "ks",
-    "external_link": ""
+    "external_link": " "
   },
   "kentucky" : {
     "file": "kentucky",
     "title": "Kentucky",
     "state_abbreviation": "ky",
-    "external_link": ""
+    "external_link": " "
   },
   "louisiana" : {
     "file": "luisiana",
     "title": "Luisiana",
     "state_abbreviation": "la",
-    "external_link": ""
+    "external_link": " "
   },
   "maine" : {
     "file": "maine",
     "title": "Maine",
     "state_abbreviation": "me",
-    "external_link": ""
+    "external_link": " "
   },
   "maryland" : {
     "file": "maryland",
     "title": "Maryland",
     "state_abbreviation": "md",
-    "external_link": ""
+    "external_link": " "
   },
   "massachusetts" : {
     "file": "massachusetts",
     "title": "Massachusetts",
     "state_abbreviation": "ma",
-    "external_link": ""
+    "external_link": " "
   },
   "michigan" : {
     "file": "michigan",
     "title": "Michigan",
     "state_abbreviation": "mi",
-    "external_link": ""
+    "external_link": " "
   },
   "minnesota" : {
     "file": "minnesota",
     "title": "Minnesota",
     "state_abbreviation": "mn",
-    "external_link": ""
+    "external_link": " "
   },
   "mississippi" : {
     "file": "misisipi",
     "title": "Misisipi",
     "state_abbreviation": "ms",
-    "external_link": ""
+    "external_link": " "
   },
   "missouri" : {
     "file": "misuri",
     "title": "Misuri",
     "state_abbreviation": "mo",
-    "external_link": ""
+    "external_link": " "
   },
   "montana" : {
     "file": "montana",
     "title": "Montana",
     "state_abbreviation": "mt",
-    "external_link": ""
+    "external_link": " "
   },
   "nebraska" : {
     "file": "nebraska",
     "title": "Nebraska",
     "state_abbreviation": "ne",
-    "external_link": ""
+    "external_link": " "
   },
   "nevada" : {
     "file": "nevada",
     "title": "Nevada",
     "state_abbreviation": "nv",
-    "external_link": ""
+    "external_link": " "
   },
   "new-hampshire" : {
     "file": "nuevo-hampshire",
     "title": "Nuevo Hampshire",
     "state_abbreviation": "nh",
-    "external_link": ""
+    "external_link": " "
   },
   "new-jersey" : {
     "file": "nueva-jersey",
     "title": "Nueva Jersey",
     "state_abbreviation": "nj",
-    "external_link": ""
+    "external_link": " "
   },
   "new-mexico" : {
     "file": "nuevo-mexico",
     "title": "Nuevo México",
     "state_abbreviation": "nm",
-    "external_link": ""
+    "external_link": " "
   },
   "new-york" : {
     "file": "nueva-york",
     "title": "Nueva York",
     "state_abbreviation": "ny",
-    "external_link": ""
+    "external_link": " "
   },
   "north-carolina" : {
     "file": "carolina-del-norte",
     "title": "Carolina del Norte",
     "state_abbreviation": "nc",
-    "external_link": ""
+    "external_link": " "
   },
   "north-dakota" : {
     "file": "dakota-del-norte",
     "title": "Dakota del Norte",
     "state_abbreviation": "nd",
-    "external_link": ""
+    "external_link": " "
   },
   "northern-mariana-islands" : {
     "file": "islas-marianas-del-norte",
     "title": "Islas Marianas del Norte",
     "state_abbreviation": "mp",
-    "external_link": ""
+    "external_link": " "
   },
   "ohio" : {
     "file": "ohio",
     "title": "Ohio",
     "state_abbreviation": "oh",
-    "external_link": ""
+    "external_link": " "
   },
   "oklahoma" : {
     "file": "oklahoma",
     "title": "Oklahoma",
     "state_abbreviation": "ok",
-    "external_link": ""
+    "external_link": " "
   },
   "oregon" : {
     "file": "oregon",
     "title": "Oregón",
     "state_abbreviation": "or",
-    "external_link": "test"
+    "external_link": " "
   },
   "pennsylvania" : {
     "file": "pensilvania",
     "title": "Pensilvania",
     "state_abbreviation": "pa",
-    "external_link": ""
+    "external_link": " "
   },
   "puerto-rico" : {
     "file": "puerto-rico",
     "title": "Puerto Rico",
     "state_abbreviation": "pr",
-    "external_link": ""
+    "external_link": " "
   },
   "rhode-island" : {
     "file": "rhode-island",
     "title": "Rhode Island",
     "state_abbreviation": "ri",
-    "external_link": ""
+    "external_link": " "
   },
   "south-dakota": {
     "file": "dakota-del-sur",
     "title": "Dakota del Sur",
     "state_abbreviation": "sd",
-    "external_link": ""
+    "external_link": " "
   },
   "south-carolina" : {
     "file": "carolina-del-sur",
     "title": "Carolina del Sur",
     "state_abbreviation": "sc",
-    "external_link": ""
+    "external_link": " "
   },
   "tennessee": {
     "file": "tenesi",
     "title": "Tennessee",
     "state_abbreviation": "tn",
-    "external_link": ""
+    "external_link": " "
   },
   "texas": {
     "file": "texas",
     "title": "Texas",
     "state_abbreviation": "tx",
-    "external_link": ""
+    "external_link": " "
   },
   "us-virgin-islands" : {
     "file": "islas-virgenes-de-ee-uu",
     "title": "Islas Vírgenes de EE. UU.",
     "state_abbreviation": "vi",
-    "external_link": ""
+    "external_link": " "
   },
   "utah" : {
     "file": "utah",
     "title": "Utah",
     "state_abbreviation": "ut",
-    "external_link": ""
+    "external_link": " "
   },
   "vermont" : {
     "file": "vermont",
     "title": "Vermont",
     "state_abbreviation": "vt",
-    "external_link": ""
+    "external_link": " "
   },
   "virginia" : {
     "file": "virginia",
     "title": "Virginia",
     "state_abbreviation": "va",
-    "external_link": ""
+    "external_link": " "
   },
   "west-virginia" : {
     "file": "virginia-occidental",
     "title": "Virginia Occidental",
     "state_abbreviation": "wv",
-    "external_link": ""
+    "external_link": " "
   },
   "washington" : {
     "file": "washington",
     "title": "Washington",
     "state_abbreviation": "wa",
-    "external_link": ""
+    "external_link": " "
   },
   "wisconsin" : {
     "file": "wisconsin",
     "title": "Wisconsin",
     "state_abbreviation": "wi",
-    "external_link": ""
+    "external_link": " "
   },
   "wyoming" : {
     "file": "wyoming",
     "title": "Wyoming",
     "state_abbreviation": "wy",
-    "external_link": ""
+    "external_link": " "
   }
 }

--- a/config/gulp/lang/spanish/state-names.json
+++ b/config/gulp/lang/spanish/state-names.json
@@ -3,26 +3,26 @@
     "file": "alabama",
     "title": "Alabama",
     "state_abbreviation": "al",
-    "external_link": "test"
+    "external_link": ""
   },
   "alaska" : {
     "file": "alaska",
     "title": "Alaska",
     "state_abbreviation": "ak",
-    "external_link": "test"
+    "external_link": ""
 
   },
   "american-samoa" : {
     "file": "samoa-americana",
     "title": "Samoa Americana",
     "state_abbreviation": "as",
-    "external_link": "test"
+    "external_link": ""
   },
   "arizona" : {
     "file": "arizona",
     "title": "Arizona",
     "state_abbreviation": "az",
-    "external_link": "test2"
+    "external_link": ""
   },
   "arkansas" : {
     "file": "arkansas",
@@ -40,7 +40,7 @@
     "file": "colorado",
     "title": "Colorado",
     "state_abbreviation": "co",
-    "external_link": ""
+    "external_link": "https://www.sos.state.co.us/pubs/spanish/spanishHome.html"
   },
   "connecticut" : {
     "file": "conecticut",
@@ -154,7 +154,7 @@
     "file": "minnesota",
     "title": "Minnesota",
     "state_abbreviation": "mn",
-    "external_link": ""
+    "external_link": "https://www.sos.state.mn.us/elections-voting/spanish"
   },
   "mississippi" : {
     "file": "misisipi",
@@ -178,7 +178,7 @@
     "file": "nebraska",
     "title": "Nebraska",
     "state_abbreviation": "ne",
-    "external_link": ""
+    "external_link": " https://www.nebraska.gov/apps-sos-voter-registration/?lang=es"
   },
   "nevada" : {
     "file": "nevada",
@@ -244,7 +244,7 @@
     "file": "oregon",
     "title": "Oregón",
     "state_abbreviation": "or",
-    "external_link": ""
+    "external_link": "https://secure.sos.state.or.us/orestar/vr/register.do?lang=spa"
   },
   "pennsylvania" : {
     "file": "pensilvania",
@@ -328,7 +328,7 @@
     "file": "wisconsin",
     "title": "Wisconsin",
     "state_abbreviation": "wi",
-    "external_link": ""
+    "external_link": "https://myvote.wi.gov/es-es/RegisterToVote/"
   },
   "wyoming" : {
     "file": "wyoming",

--- a/config/gulp/lang/spanish/state-names.json
+++ b/config/gulp/lang/spanish/state-names.json
@@ -22,318 +22,318 @@
     "file": "arizona",
     "title": "Arizona",
     "state_abbreviation": "az",
-    "external_link": " "
+    "external_link": "test2"
   },
   "arkansas" : {
     "file": "arkansas",
     "title": "Arkansas",
     "state_abbreviation": "ar",
-    "external_link": " "
+    "external_link": ""
   },
   "california" : {
     "file": "california",
     "title": "California",
     "state_abbreviation": "ca",
-    "external_link": " "
+    "external_link": ""
   },
   "colorado" : {
     "file": "colorado",
     "title": "Colorado",
     "state_abbreviation": "co",
-    "external_link": " "
+    "external_link": ""
   },
   "connecticut" : {
     "file": "conecticut",
     "title": "Connecticut",
     "state_abbreviation": "ct",
-    "external_link": " "
+    "external_link": ""
   },
   "delaware" : {
     "file": "delaware",
     "title": "Delaware",
     "state_abbreviation": "de",
-    "external_link": " "
+    "external_link": ""
   },
   "washington-dc" : {
     "file": "distrito-de-columbia",
     "title": "Distrito de Columbia",
     "state_abbreviation": "dc",
-    "external_link": " "
+    "external_link": ""
   },
   "florida" : {
     "file": "florida",
     "title": "Florida",
     "state_abbreviation": "fl",
-    "external_link": " "
+    "external_link": ""
   },
   "georgia" : {
     "file": "georgia",
     "title": "Georgia",
     "state_abbreviation": "ga",
-    "external_link": " "
+    "external_link": ""
   },
   "guam" : {
     "file": "guam",
     "title": "Guam",
     "state_abbreviation": "gu",
-    "external_link": " "
+    "external_link": ""
   },
   "hawaii" : {
     "file": "hawai",
     "title": "Hawai",
     "state_abbreviation": "hi",
-    "external_link": " "
+    "external_link": ""
   },
   "idaho" : {
     "file": "idaho",
     "title": "Idaho",
     "state_abbreviation": "id",
-    "external_link": " "
+    "external_link": ""
   },
   "illinois" : {
     "file": "illinois",
     "title": "Illinois",
     "state_abbreviation": "il",
-    "external_link": " "
+    "external_link": ""
   },
   "indiana" : {
     "file": "indiana",
     "title": "Indiana",
     "state_abbreviation": "in",
-    "external_link": " "
+    "external_link": ""
   },
   "iowa" : {
     "file": "iowa",
     "title": "Iowa",
     "state_abbreviation": "ia",
-    "external_link": " "
+    "external_link": ""
   },
   "kansas" : {
     "file": "kansas",
     "title": "Kansas",
     "state_abbreviation": "ks",
-    "external_link": " "
+    "external_link": ""
   },
   "kentucky" : {
     "file": "kentucky",
     "title": "Kentucky",
     "state_abbreviation": "ky",
-    "external_link": " "
+    "external_link": ""
   },
   "louisiana" : {
     "file": "luisiana",
     "title": "Luisiana",
     "state_abbreviation": "la",
-    "external_link": " "
+    "external_link": ""
   },
   "maine" : {
     "file": "maine",
     "title": "Maine",
     "state_abbreviation": "me",
-    "external_link": " "
+    "external_link": ""
   },
   "maryland" : {
     "file": "maryland",
     "title": "Maryland",
     "state_abbreviation": "md",
-    "external_link": " "
+    "external_link": ""
   },
   "massachusetts" : {
     "file": "massachusetts",
     "title": "Massachusetts",
     "state_abbreviation": "ma",
-    "external_link": " "
+    "external_link": ""
   },
   "michigan" : {
     "file": "michigan",
     "title": "Michigan",
     "state_abbreviation": "mi",
-    "external_link": " "
+    "external_link": ""
   },
   "minnesota" : {
     "file": "minnesota",
     "title": "Minnesota",
     "state_abbreviation": "mn",
-    "external_link": " "
+    "external_link": ""
   },
   "mississippi" : {
     "file": "misisipi",
     "title": "Misisipi",
     "state_abbreviation": "ms",
-    "external_link": " "
+    "external_link": ""
   },
   "missouri" : {
     "file": "misuri",
     "title": "Misuri",
     "state_abbreviation": "mo",
-    "external_link": " "
+    "external_link": ""
   },
   "montana" : {
     "file": "montana",
     "title": "Montana",
     "state_abbreviation": "mt",
-    "external_link": " "
+    "external_link": ""
   },
   "nebraska" : {
     "file": "nebraska",
     "title": "Nebraska",
     "state_abbreviation": "ne",
-    "external_link": " "
+    "external_link": ""
   },
   "nevada" : {
     "file": "nevada",
     "title": "Nevada",
     "state_abbreviation": "nv",
-    "external_link": " "
+    "external_link": ""
   },
   "new-hampshire" : {
     "file": "nuevo-hampshire",
     "title": "Nuevo Hampshire",
     "state_abbreviation": "nh",
-    "external_link": " "
+    "external_link": ""
   },
   "new-jersey" : {
     "file": "nueva-jersey",
     "title": "Nueva Jersey",
     "state_abbreviation": "nj",
-    "external_link": " "
+    "external_link": ""
   },
   "new-mexico" : {
     "file": "nuevo-mexico",
     "title": "Nuevo México",
     "state_abbreviation": "nm",
-    "external_link": " "
+    "external_link": ""
   },
   "new-york" : {
     "file": "nueva-york",
     "title": "Nueva York",
     "state_abbreviation": "ny",
-    "external_link": " "
+    "external_link": ""
   },
   "north-carolina" : {
     "file": "carolina-del-norte",
     "title": "Carolina del Norte",
     "state_abbreviation": "nc",
-    "external_link": " "
+    "external_link": ""
   },
   "north-dakota" : {
     "file": "dakota-del-norte",
     "title": "Dakota del Norte",
     "state_abbreviation": "nd",
-    "external_link": " "
+    "external_link": ""
   },
   "northern-mariana-islands" : {
     "file": "islas-marianas-del-norte",
     "title": "Islas Marianas del Norte",
     "state_abbreviation": "mp",
-    "external_link": " "
+    "external_link": ""
   },
   "ohio" : {
     "file": "ohio",
     "title": "Ohio",
     "state_abbreviation": "oh",
-    "external_link": " "
+    "external_link": ""
   },
   "oklahoma" : {
     "file": "oklahoma",
     "title": "Oklahoma",
     "state_abbreviation": "ok",
-    "external_link": " "
+    "external_link": ""
   },
   "oregon" : {
     "file": "oregon",
     "title": "Oregón",
     "state_abbreviation": "or",
-    "external_link": " "
+    "external_link": ""
   },
   "pennsylvania" : {
     "file": "pensilvania",
     "title": "Pensilvania",
     "state_abbreviation": "pa",
-    "external_link": " "
+    "external_link": ""
   },
   "puerto-rico" : {
     "file": "puerto-rico",
     "title": "Puerto Rico",
     "state_abbreviation": "pr",
-    "external_link": " "
+    "external_link": ""
   },
   "rhode-island" : {
     "file": "rhode-island",
     "title": "Rhode Island",
     "state_abbreviation": "ri",
-    "external_link": " "
+    "external_link": ""
   },
   "south-dakota": {
     "file": "dakota-del-sur",
     "title": "Dakota del Sur",
     "state_abbreviation": "sd",
-    "external_link": " "
+    "external_link": ""
   },
   "south-carolina" : {
     "file": "carolina-del-sur",
     "title": "Carolina del Sur",
     "state_abbreviation": "sc",
-    "external_link": " "
+    "external_link": ""
   },
   "tennessee": {
     "file": "tenesi",
     "title": "Tennessee",
     "state_abbreviation": "tn",
-    "external_link": " "
+    "external_link": ""
   },
   "texas": {
     "file": "texas",
     "title": "Texas",
     "state_abbreviation": "tx",
-    "external_link": " "
+    "external_link": ""
   },
   "us-virgin-islands" : {
     "file": "islas-virgenes-de-ee-uu",
     "title": "Islas Vírgenes de EE. UU.",
     "state_abbreviation": "vi",
-    "external_link": " "
+    "external_link": ""
   },
   "utah" : {
     "file": "utah",
     "title": "Utah",
     "state_abbreviation": "ut",
-    "external_link": " "
+    "external_link": ""
   },
   "vermont" : {
     "file": "vermont",
     "title": "Vermont",
     "state_abbreviation": "vt",
-    "external_link": " "
+    "external_link": ""
   },
   "virginia" : {
     "file": "virginia",
     "title": "Virginia",
     "state_abbreviation": "va",
-    "external_link": " "
+    "external_link": ""
   },
   "west-virginia" : {
     "file": "virginia-occidental",
     "title": "Virginia Occidental",
     "state_abbreviation": "wv",
-    "external_link": " "
+    "external_link": ""
   },
   "washington" : {
     "file": "washington",
     "title": "Washington",
     "state_abbreviation": "wa",
-    "external_link": " "
+    "external_link": ""
   },
   "wisconsin" : {
     "file": "wisconsin",
     "title": "Wisconsin",
     "state_abbreviation": "wi",
-    "external_link": " "
+    "external_link": ""
   },
   "wyoming" : {
     "file": "wyoming",
     "title": "Wyoming",
     "state_abbreviation": "wy",
-    "external_link": " "
+    "external_link": ""
   }
 }

--- a/config/gulp/translation.js
+++ b/config/gulp/translation.js
@@ -3,6 +3,7 @@ var gutil = require('gulp-util');
 var del = require('del');
 var pkg = require('../../package.json');
 var spawn = require('cross-spawn');
+var find = require('gulp-find');
 var rename = require('gulp-rename');
 var replace = require('gulp-replace');
 var spanishStateNames = require('./lang/spanish/state-names.json');
@@ -17,7 +18,7 @@ gulp.task('clean-translation', function () {
 
 gulp.task('copy-content-spanish', function (done) {
 
-  return gulp.src('./content/register/*.md')
+  return gulp.src('./content/en/register/*.md')
     .pipe(replace(/title = "(.+)"/, function (match, p1) {
       var name = p1.replace(/\s/g, '-').replace(/\./g, '').toLowerCase();
       var title = spanishStateNames[name].title;
@@ -25,7 +26,7 @@ gulp.task('copy-content-spanish', function (done) {
         'title = "' + title + '"'
       );
     }))
-    .pipe(gulp.dest('./content/registrar'));
+    .pipe(gulp.dest('./content/es/registrar'));
 
 });
 
@@ -47,13 +48,61 @@ gulp.task('copy-layouts-spanish', function (done) {
 
 });
 
-gulp.task('copy-translation', gulp.series( 'clean-translation', 'copy-content-spanish', 'copy-layouts-spanish'  , function (done) {
+// gulp.task('copy-links-spanish', function (done) {
+//   gutil.log(
+//     gutil.colors.cyan('copy-links-spanish'),
+//     'Copying links into state.md files.'
+//   );
+//   for (var state in spanishStateNames) {
+//      fileName = "./content/es/registrar/" + spanishStateNames[state].state_abbreviation + ".md"
+//      populate(fileName, state);
+//    };
+//    done();
+// });
+//
+// function populate(fileName,state ){
+//   return gulp.src(fileName)
+//     .pipe(replace(/external_link = "(.+)"/, function (match,p1) {
+//      var link = spanishStateNames[state].external_link;
+//       return ( 'external_link = "' + link + '"' )
+//     }))
+//     .pipe(gulp.dest('./content/es/registrar'));
+// }
 
+gulp.task('copy-links-spanish', function () {
+  return gulp.src('./content/es/registrar/*.md')
+    .pipe(replace(/external_link = "(.+)"/, function (match, p1) {
+      console.log(match);
+      var external_link = spanishStateNames[find(/title = "(.+)"/)].external_link;
+      return (
+        'external_link = "' + external_link + '"'
+      );
+    }))
+    .pipe(gulp.dest('./content/es/registrar'));
+ });
+
+ //here just for my own note
+ // gulp.task('populateStates', function () {
+ //   //from register
+ //    return gulp.src('./content/en/register/*.md')
+ //    //look through state file for title line
+ //    .pipe(scan({ term: /title = "(.+)"/ } , fn: function (match, file ,p1 ) {
+ //    //create title line variable
+ //     var stateName = match.replace(/\s/g, '-').replace(/\./g, '').toLowerCase();
+ //         }))
+ //         //replace register line with new register deadline from electionDates
+ //       .pipe(replace(/register = "(.+)"/, function (match,p1) {
+ //               var register_deadline = electionDates[stateName].important_dates[0].date;
+ //               return ('register = "' + register_deadline + '"');
+ //   }}))
+ //    //put register stuff back into register folder
+ //      .pipe(gulp.dest('./content/en/register'));
+ //   }}));
+
+gulp.task('copy-translation', gulp.series( 'clean-translation', 'copy-content-spanish', 'copy-layouts-spanish', 'copy-links-spanish'  , function (done) {
   gutil.log(
     gutil.colors.cyan('copy-translation'),
     'Copying files from content/ & layouts/ for translated URLs'
   );
-  done ();
-
-
+  done();
 }));

--- a/config/gulp/translation.js
+++ b/config/gulp/translation.js
@@ -3,7 +3,6 @@ var gutil = require('gulp-util');
 var del = require('del');
 var pkg = require('../../package.json');
 var spawn = require('cross-spawn');
-var find = require('gulp-find');
 var rename = require('gulp-rename');
 var replace = require('gulp-replace');
 var spanishStateNames = require('./lang/spanish/state-names.json');
@@ -48,56 +47,39 @@ gulp.task('copy-layouts-spanish', function (done) {
 
 });
 
-// gulp.task('copy-links-spanish', function (done) {
-//   gutil.log(
-//     gutil.colors.cyan('copy-links-spanish'),
-//     'Copying links into state.md files.'
-//   );
-//   for (var state in spanishStateNames) {
-//      fileName = "./content/es/registrar/" + spanishStateNames[state].state_abbreviation + ".md"
-//      populate(fileName, state);
-//    };
-//    done();
-// });
-//
-// function populate(fileName,state ){
-//   return gulp.src(fileName)
-//     .pipe(replace(/external_link = "(.+)"/, function (match,p1) {
-//      var link = spanishStateNames[state].external_link;
-//       return ( 'external_link = "' + link + '"' )
-//     }))
-//     .pipe(gulp.dest('./content/es/registrar'));
-// }
+gulp.task('copy-links-spanish', function (done) {
+  gutil.log(
+    gutil.colors.cyan('copy-links-spanish'),
+    'Copying links into state.md files.'
+  );
+  for (var state in spanishStateNames) {
+    // console.log(state);
+     fileName = "./content/es/registrar/" + spanishStateNames[state].state_abbreviation + ".md"
+     populate(fileName, state);
+   };
+   done();
+});
 
-gulp.task('copy-links-spanish', function () {
-  return gulp.src('./content/es/registrar/*.md')
-    .pipe(replace(/external_link = "(.+)"/, function (match, p1) {
-      console.log(match);
-      var external_link = spanishStateNames[find(/title = "(.+)"/)].external_link;
-      return (
-        'external_link = "' + external_link + '"'
-      );
+function populate(fileName,state ){
+  // console.log(state);
+  return gulp.src(fileName)
+    .pipe(replace(/external_link = "(.+)"/, function (match,p1) {
+      // console.log (fileName, "===>",state, "===>" , link);
+     var link = spanishStateNames[state].external_link;
+     if (link != " " ){
+       // console.log("NO EMPTY", link)
+         return ( 'external_link = "' + link + '"' )
+
+     } else {
+       // console.log(" EMPTY" ,p1 )
+         return ( 'external_link = "' + p1 + '"' )
+
+     }
+
     }))
     .pipe(gulp.dest('./content/es/registrar'));
- });
+}
 
- //here just for my own note
- // gulp.task('populateStates', function () {
- //   //from register
- //    return gulp.src('./content/en/register/*.md')
- //    //look through state file for title line
- //    .pipe(scan({ term: /title = "(.+)"/ } , fn: function (match, file ,p1 ) {
- //    //create title line variable
- //     var stateName = match.replace(/\s/g, '-').replace(/\./g, '').toLowerCase();
- //         }))
- //         //replace register line with new register deadline from electionDates
- //       .pipe(replace(/register = "(.+)"/, function (match,p1) {
- //               var register_deadline = electionDates[stateName].important_dates[0].date;
- //               return ('register = "' + register_deadline + '"');
- //   }}))
- //    //put register stuff back into register folder
- //      .pipe(gulp.dest('./content/en/register'));
- //   }}));
 
 gulp.task('copy-translation', gulp.series( 'clean-translation', 'copy-content-spanish', 'copy-layouts-spanish', 'copy-links-spanish'  , function (done) {
   gutil.log(

--- a/config/gulp/translation.js
+++ b/config/gulp/translation.js
@@ -53,7 +53,6 @@ gulp.task('copy-links-spanish', function (done) {
     'Copying links into state.md files.'
   );
   for (var state in spanishStateNames) {
-    // console.log(state);
      fileName = "./content/es/registrar/" + spanishStateNames[state].state_abbreviation + ".md"
      populate(fileName, state);
    };
@@ -61,25 +60,17 @@ gulp.task('copy-links-spanish', function (done) {
 });
 
 function populate(fileName,state ){
-  // console.log(state);
   return gulp.src(fileName)
-    .pipe(replace(/external_link = "(.+)"/, function (match,p1) {
-      // console.log (fileName, "===>",state, "===>" , link);
+    .pipe(replace(/external_link = "(.*)"/, function (match,p1) {
      var link = spanishStateNames[state].external_link;
-     if (link != " " ){
-       // console.log("NO EMPTY", link)
+     if (link != "" ){
          return ( 'external_link = "' + link + '"' )
-
      } else {
-       // console.log(" EMPTY" ,p1 )
          return ( 'external_link = "' + p1 + '"' )
-
      }
-
     }))
     .pipe(gulp.dest('./content/es/registrar'));
 }
-
 
 gulp.task('copy-translation', gulp.series( 'clean-translation', 'copy-content-spanish', 'copy-layouts-spanish', 'copy-links-spanish'  , function (done) {
   gutil.log(

--- a/layouts/registrar/types/by-mail.html
+++ b/layouts/registrar/types/by-mail.html
@@ -1,47 +1,49 @@
 {{ $translation := ( index $.Site.Data.translations $.Site.Params.language ) }}
 
-<div class="usa-grid page-inner mail-steps">
+<div class="grid-container page-inner mail-steps">
   <h1>
     {{ $translation.register.heading }}
   </h1>
-  <p class="usa-font-lead">
+  <p class="usa-intro">
     {{ replace $translation.register.by_mail.body "%state_name%" ( title .Title ) }}
   </p>
   <!-- Steps BEGIN -->
-  <div class="graphic-list">
-    <div class="usa-width-one-third">
-      <img src="{{ .Site.BaseURL }}assets/img/step-1.png">
-      <h4 class="usa-graphic-list-heading">
-        {{ $translation.register.by_mail.step_one_label }}
-      </h4>
-      <p>
-        {{ $translation.register.by_mail.step_one }}
-      </p>
-    </div>
-    <div class="usa-width-one-third">
-      <img src="{{ .Site.BaseURL }}assets/img/step-2.png">
-      <h4 class="usa-graphic-list-heading">
-        {{ $translation.register.by_mail.step_two_label }}
-      </h4>
-      <p>
-        {{ $translation.register.by_mail.step_two }}
-      </p>
-    </div>
-    <div class="usa-width-one-third">
-      <img src="{{ .Site.BaseURL }}assets/img/step-3.png">
-      <h4 class="usa-graphic-list-heading">
-        {{ $translation.register.by_mail.step_three_label }}
-      </h4>
-      <p>
-        {{ $translation.register.by_mail.step_three }}
-      </p>
+  <div class="usa-graphic-list">
+    <div class="grid-row">
+      <div class="grid-col-4">
+        <img src="{{ .Site.BaseURL }}/assets/img/step-1.png">
+        <h4 class="usa-graphic-list__heading">
+          {{ $translation.register.by_mail.step_one_label }}
+        </h4>
+        <p>
+          {{ $translation.register.by_mail.step_one }}
+        </p>
+      </div>
+      <div class="grid-col-4">
+        <img src="{{ .Site.BaseURL }}/assets/img/step-2.png">
+        <h4 class="usa-graphic-list__heading">
+          {{ $translation.register.by_mail.step_two_label }}
+        </h4>
+        <p>
+          {{ $translation.register.by_mail.step_two }}
+        </p>
+      </div>
+      <div class="grid-col-4">
+        <img src="{{ .Site.BaseURL }}/assets/img/step-3.png">
+        <h4 class="usa-graphic-list__heading">
+          {{ $translation.register.by_mail.step_three_label }}
+        </h4>
+        <p>
+          {{ $translation.register.by_mail.step_three }}
+        </p>
+      </div>
     </div>
   </div>
   <!-- Steps END -->
 </div>
 
 <!-- Download form BEGIN -->
-<div class="usa-grid page-inner mail-download">
+<div class="grid-container page-inner mail-download">
   {{ range $key, $form := $.Site.Data.registration_forms }}
     {{ if eq $key $.Site.Params.language }}
     <a class="usa-button" href="{{ $form.file_path }}" target="_blank">
@@ -52,7 +54,7 @@
   <p>
     {{ $translation.register.by_mail.download_others }}
   </p>
-  <ul class="usa-unstyled-list mail-download-list">
+  <ul class=".usa-list.usa-list--unstyled  mail-download-list">
     {{ range $key, $form := $.Site.Data.registration_forms }}
       {{ if ne $key $.Site.Params.language }}
         <li>

--- a/layouts/registrar/types/in-person.html
+++ b/layouts/registrar/types/in-person.html
@@ -1,20 +1,22 @@
 {{ $translation := ( index $.Site.Data.translations $.Site.Params.language ) }}
 
 <!-- Register BEGIN -->
-<div class="usa-grid page-inner main-content">
+<div class="grid-container page-inner main-content">
   <header>
     <h1>
       {{ $translation.register.heading }}
     </h1>
   </header>
-  <p class="usa-font-lead">
+  <p class="usa-intro">
     {{ replace $translation.register.in_person.body "%state_name%" ( title .Title ) }}
   </p>
   <p>
     <a href="{{ .Params.external_link }}">
       {{ replace $translation.register.in_person.link "%state_name%" ( title .Title ) }}
+      {{ if and (eq $.Site.Params.language "spanish") (eq .Params.english_only true) }}
+        {{ $translation.register.english_only }}
+      {{ else }} {{ end }}
     </a>
   </p>
 </div>
 <!-- Register END -->
-

--- a/layouts/registrar/types/not-needed.html
+++ b/layouts/registrar/types/not-needed.html
@@ -1,13 +1,13 @@
 {{ $translation := ( index $.Site.Data.translations $.Site.Params.language ) }}
 
 <!-- Register BEGIN -->
-<div class="usa-grid page-inner main-content">
+<div class="grid-container page-inner main-content">
   <header>
     <h1>
       {{ $translation.register.not_needed.heading }}
     </h1>
   </header>
-  <p class="usa-font-lead">
+  <p class="usa-intro">
     {{ replace $translation.register.not_needed.body "%state_name%" ( title .Title ) }}
   </p>
   <p>

--- a/layouts/registrar/types/online.html
+++ b/layouts/registrar/types/online.html
@@ -1,17 +1,20 @@
 {{ $translation := ( index $.Site.Data.translations $.Site.Params.language ) }}
 <!-- Register BEGIN -->
-<div class="usa-grid page-inner main-content">
+<div class="grid-container page-inner main-content">
   <header>
     <h1>
       {{ $translation.register.heading }}
     </h1>
   </header>
-  <p class="usa-font-lead">
+  <p class="usa-intro">
     {{ replace $translation.register.online.body "%state_name%" ( title .Title ) }}
   </p>
   <p>
     <a href="{{ .Params.external_link }}?ref={{ $.Site.Params.Referrer_Short_Code }}">
-      {{ $translation.register.online.link }}
+      {{ replace $translation.register.online.link "%state_name%" ( title .Title ) }}
+      {{ if and (eq $.Site.Params.language "spanish") (eq .Params.english_only true) }}
+        {{ $translation.register.english_only }}
+      {{ else }} {{ end }}
     </a>
   </p>
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,39 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@gulp-sourcemaps/identity-map": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.2.tgz",
-      "integrity": "sha512-ciiioYMLdo16ShmfHBXJBOFm3xPC4AuwO4xeRpFeHz7WK9PYsWCmigagG2XyzZpubK4a3qNKoUBDhbzHfa50LQ==",
-      "requires": {
-        "acorn": "^5.0.3",
-        "css": "^2.2.1",
-        "normalize-path": "^2.1.1",
-        "source-map": "^0.6.0",
-        "through2": "^2.0.3"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
-    },
-    "@gulp-sourcemaps/map-sources": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
-      "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
-      "requires": {
-        "normalize-path": "^2.0.1",
-        "through2": "^2.0.3"
-      }
-    },
     "@types/node": {
       "version": "8.10.49",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.49.tgz",
@@ -195,7 +162,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
       "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
-      "dev": true,
       "requires": {
         "buffer-equal": "^1.0.0"
       }
@@ -798,8 +764,7 @@
     "buffer-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-      "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
-      "dev": true
+      "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -1008,8 +973,7 @@
     "clone-buffer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-      "dev": true
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
     },
     "clone-stats": {
       "version": "0.0.1",
@@ -1020,7 +984,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
       "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "process-nextick-args": "^2.0.0",
@@ -1338,7 +1301,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -1497,7 +1459,6 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -1509,7 +1470,6 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-          "dev": true,
           "requires": {
             "once": "^1.4.0"
           }
@@ -2129,7 +2089,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
       "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
@@ -2181,7 +2140,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
       "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
         "through2": "^2.0.3"
@@ -2792,75 +2750,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-      "dev": true,
-      "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      }
-    },
-    "glob-stream": {
-      "version": "3.1.18",
-      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-      "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
-      "requires": {
-        "glob": "^4.3.1",
-        "glob2base": "^0.0.12",
-        "minimatch": "^2.0.1",
-        "ordered-read-streams": "^0.1.0",
-        "through2": "^0.6.1",
-        "unique-stream": "^1.0.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "4.5.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^2.0.1",
-            "once": "^1.3.0"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "requires": {
-            "brace-expansion": "^1.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          }
-        }
-      }
-    },
-    "glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "requires": {
         "is-glob": "^3.1.0",
         "path-dirname": "^1.0.0"
@@ -2998,46 +2887,6 @@
         }
       }
     },
-    "gulp-cli": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
-      "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
-      "dev": true,
-      "requires": {
-        "ansi-colors": "^1.0.1",
-        "archy": "^1.0.0",
-        "array-sort": "^1.0.0",
-        "color-support": "^1.1.3",
-        "concat-stream": "^1.6.0",
-        "copy-props": "^2.0.1",
-        "fancy-log": "^1.3.2",
-        "gulplog": "^1.0.0",
-        "interpret": "^1.1.0",
-        "isobject": "^3.0.1",
-        "liftoff": "^3.1.0",
-        "matchdep": "^2.0.0",
-        "mute-stdout": "^1.0.0",
-        "pretty-hrtime": "^1.0.0",
-        "replace-homedir": "^1.0.0",
-        "semver-greatest-satisfied-range": "^1.1.0",
-        "v8flags": "^3.0.1",
-        "yargs": "^7.1.0"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
-          }
-        }
-      }
-    },
     "gulp-eslint": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-2.1.0.tgz",
@@ -3057,6 +2906,16 @@
         "gulp-util": "^3.0.6",
         "multimatch": "^2.0.0",
         "streamfilter": "^1.0.5"
+      }
+    },
+    "gulp-find": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/gulp-find/-/gulp-find-0.0.10.tgz",
+      "integrity": "sha1-2Qlcs/aq+1QlbrIFWqIZOZRKxzo=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.6",
+        "replacestream": "^4.0.0"
       }
     },
     "gulp-rename": {
@@ -3237,7 +3096,6 @@
             "extend-shallow": "^3.0.2"
           }
         },
-
         "replace-ext": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
@@ -3428,8 +3286,7 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-      "dev": true
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -3780,8 +3637,7 @@
     "is-negated-glob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-      "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
-      "dev": true
+      "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI="
     },
     "is-number": {
       "version": "3.0.0",
@@ -3874,8 +3730,7 @@
     "is-valid-glob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-      "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
-      "dev": true
+      "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -3952,8 +3807,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "dev": true
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -3990,6 +3844,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
       "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo="
+    },
+    "keyboardevent-key-polyfill": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keyboardevent-key-polyfill/-/keyboardevent-key-polyfill-1.1.0.tgz",
+      "integrity": "sha1-ijGdjkWhMXL8pWKGNy+QwdTHAUw="
     },
     "kind-of": {
       "version": "6.0.2",
@@ -4031,7 +3890,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-      "dev": true,
       "requires": {
         "readable-stream": "^2.0.5"
       }
@@ -4048,7 +3906,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
       "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
-      "dev": true,
       "requires": {
         "flush-write-stream": "^1.0.2"
       }
@@ -4345,6 +4202,11 @@
         }
       }
     },
+    "matches-selector": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-1.2.0.tgz",
+      "integrity": "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA=="
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -4363,21 +4225,6 @@
         "map-age-cleaner": "^0.1.1",
         "mimic-fn": "^2.0.0",
         "p-is-promise": "^2.0.0"
-      }
-    },
-    "memoizee": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
-      "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.45",
-        "es6-weak-map": "^2.0.2",
-        "event-emitter": "^0.3.5",
-        "is-promise": "^2.1",
-        "lru-queue": "0.1",
-        "next-tick": "1",
-        "timers-ext": "^0.1.5"
       }
     },
     "meow": {
@@ -4718,7 +4565,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -4727,7 +4573,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
       "integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
-      "dev": true,
       "requires": {
         "once": "^1.3.2"
       }
@@ -4797,8 +4642,7 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -4812,7 +4656,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -5026,8 +4869,7 @@
     "path-dirname": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "dev": true
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
     },
     "path-exists": {
       "version": "2.1.0",
@@ -5145,18 +4987,6 @@
         "find-up": "^1.0.0"
       }
     },
-    "plugin-error": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
-      "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
-      "dev": true,
-      "requires": {
-        "ansi-colors": "^1.0.1",
-        "arr-diff": "^4.0.0",
-        "arr-union": "^3.1.0",
-        "extend-shallow": "^3.0.2"
-      }
-    },
     "pluralize": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
@@ -5225,7 +5055,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -5235,7 +5064,6 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-          "dev": true,
           "requires": {
             "once": "^1.4.0"
           }
@@ -5246,7 +5074,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-      "dev": true,
       "requires": {
         "duplexify": "^3.6.0",
         "inherits": "^2.0.3",
@@ -5402,7 +5229,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
       "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
-      "dev": true,
       "requires": {
         "is-buffer": "^1.1.5",
         "is-utf8": "^0.2.1"
@@ -5412,7 +5238,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
       "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
-      "dev": true,
       "requires": {
         "remove-bom-buffer": "^3.0.0",
         "safe-buffer": "^5.1.0",
@@ -5422,8 +5247,7 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "repeat-element": {
       "version": "1.1.3",
@@ -5545,7 +5369,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
       "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
-      "dev": true,
       "requires": {
         "value-or-function": "^3.0.0"
       }
@@ -5761,11 +5584,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
       "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg="
-    },
-    "shellwords": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -6057,8 +5875,7 @@
     "stream-shift": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-      "dev": true
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "stream-splicer": {
       "version": "2.0.0",
@@ -6099,21 +5916,6 @@
       "requires": {
         "ansi-regex": "^2.0.0"
       }
-    },
-    "strip-bom": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-      "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-      "requires": {
-        "first-chunk-stream": "^1.0.0",
-        "is-utf8": "^0.2.0"
-      }
-
-    },
-    "strip-bom-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -6243,7 +6045,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
       "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
-      "dev": true,
       "requires": {
         "through2": "~2.0.0",
         "xtend": "~4.0.0"
@@ -6266,7 +6067,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
       "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
-      "dev": true,
       "requires": {
         "is-absolute": "^1.0.0",
         "is-negated-glob": "^1.0.0"
@@ -6319,7 +6119,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
       "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
-      "dev": true,
       "requires": {
         "through2": "^2.0.3"
       }
@@ -6780,8 +6579,7 @@
     "value-or-function": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
-      "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
-      "dev": true
+      "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM="
     },
     "verror": {
       "version": "1.10.0",
@@ -6909,7 +6707,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
       "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
-      "dev": true,
       "requires": {
         "append-buffer": "^1.0.2",
         "convert-source-map": "^1.5.0",
@@ -6923,20 +6720,17 @@
         "clone": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-          "dev": true
+          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
         },
         "clone-stats": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-          "dev": true
+          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
         },
         "convert-source-map": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
           "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.1"
           }
@@ -6944,14 +6738,12 @@
         "replace-ext": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-          "dev": true
+          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
         },
         "vinyl": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
           "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-          "dev": true,
           "requires": {
             "clone": "^2.1.1",
             "clone-buffer": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "vinyl-source-stream": "^2.0.0"
   },
   "devDependencies": {
+    "gulp-find": "0.0.10",
     "gulp-scss-lint": "^1.0.0"
   }
 }


### PR DESCRIPTION

With these changes the Spanish state.md files will change their external_link URL to the appropriate Spanish state page, if there is one. If no Spanish state URL is found it keeps the English state page url. 

Files changed: 

1. State-names.json:
 
     - Added an external_link property for every state track which states needed an updated Spanish link. 

2. Translation.js:

    - Created a gulp task that replaces the external link in Spanish state.md file or leaves the English external link. 
