### PR TITLE
Inner state page sizing

### DIFF
--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -235,7 +235,7 @@ footer {
 .main-content {
 
   @include at-media('tablet') {
-    min-height: 50rem;
+    min-height: 35rem;
   }
 }
 

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -100,7 +100,7 @@ footer {
 
 
 .page-inner {
-  max-width: 63.8rem;
+  max-width: 35rem;
 }
 
 // Home page ------------ //
@@ -160,7 +160,7 @@ footer {
   }
 
   .page-inner {
-    min-height: 50rem;
+    min-height: 35rem;
 
     @include at-media('tablet') {
       min-height: 60rem;


### PR DESCRIPTION
This fixes an inconsistency from the old site where the "go back" footer was not visible on some screen sizes without scrolling down. 

The height of the inner state registration page's main section was shortened so that the "go back" can be seen. This reduces the amount of blank space between the page content and the footer. The main content section is also centered on the screen. 