### PR TITLE
Updating text on state pages

### DIFF
--- a/data/translations/english/register.toml
+++ b/data/translations/english/register.toml
@@ -16,9 +16,9 @@ body = "Register in person at your local election office."
 link = "Learn more about how to register on %state_name%'s elections website."
 
 [not_needed]
-heading = "No registration needed"
-body = "%state_name% only requires that you bring a valid state ID to your polling place."
-link = "Learn more about voting in %state_name%."
+heading = "No registration needed in %state_name%"
+body = "Bring a valid state ID to your polling place."
+link = "Learn more about voting on %state_name%'s election website."
 
 [online]
 

--- a/data/translations/english/register.toml
+++ b/data/translations/english/register.toml
@@ -1,4 +1,4 @@
-heading = "Register to vote"
+heading = "Register to vote in %state_name%"
 
 [by_mail]
 body = "%state_name% allows residents to register by mail, not online."
@@ -21,5 +21,5 @@ body = "%state_name% only requires that you bring a valid state ID to your polli
 link = "Learn more about voting in %state_name%."
 
 [online]
-body = "%state_name% allows residents to register online."
-link = "Register online on %state_name%'s election website."
+
+link = "Start your online registration on %state_name%'s election website."

--- a/data/translations/english/register.toml
+++ b/data/translations/english/register.toml
@@ -12,8 +12,8 @@ download = "Download the form (PDF)"
 download_others = "Download the form in other languages:"
 
 [in_person]
-body = "%state_name% requires residents to register in person at their local election office."
-link = "Visit the %state_name% elections site to find out how to register."
+body = "Register in person at your local election office."
+link = "Learn more about how to register on %state_name%'s elections website."
 
 [not_needed]
 heading = "No registration needed"

--- a/layouts/register/types/online.html
+++ b/layouts/register/types/online.html
@@ -3,7 +3,7 @@
 <div class="grid-container page-inner main-content">
   <header>
     <h1>
-      {{ $translation.register.heading }}
+      {{ $translation.register.heading "%state_name%" ( title .Title ) }}
     </h1>
   </header>
   <p class="usa-intro">


### PR DESCRIPTION
Want to update the text to include the state name in the heading and change link to say "Start your online registration on
Alabama’s election website."