### PR TITLE
Change Washington D.C. to District of Columbia

### DIFF
--- a/config/gulp/lang/spanish/state-names.json
+++ b/config/gulp/lang/spanish/state-names.json
@@ -54,7 +54,7 @@
     "state_abbreviation": "de",
     "external_link": "https://ivote.de.gov/VoterView/?culture=es-MX"
   },
-  "washington-dc" : {
+  "district-of-columbia" : {
     "file": "distrito-de-columbia",
     "title": "District of Columbia",
     "state_abbreviation": "dc",

--- a/content/en/register/dc.md
+++ b/content/en/register/dc.md
@@ -3,7 +3,7 @@ date = "2016-05-26T21:28:39-04:00"
 external_link = "https://www.vote4dc.com/ApplyInstructions/Register?ref=voteusa"
 registration_type = "online"
 state_abbreviation = "DC"
-title = "Washington D.C."
+title = "District of Columbia"
 english_only = true 
 
 +++


### PR DESCRIPTION
Washington, D.C. is the city and state name of the federal district, the capital of the United States. The District of Columbia is the formal name of the state and is the correct reference to its state government (that administers elections).