### PR TITLE
Updated Guam's registration text

### DIFF
--- a/data/translations/spanish/register.toml
+++ b/data/translations/spanish/register.toml
@@ -15,7 +15,7 @@ step_three_label = "Paso 3"
 step_three = "¡Vote en las próximas elecciones!"
 
 [in_person]
-body = "Inscríbase en persona en la oficina electoral local de %state_name%." 
+body = "Inscríbase en persona en la oficina electoral local." 
 link = "Visite el sitio web de %state_name% para más información sobre cómo inscribirse"
 
 [not_needed]


### PR DESCRIPTION
Delete "de Guam" to end in la oficina electoral local.