### PR TITLE
Update Mail In Date for Iowa

### DIFF
--- a/config/gulp/state-data.json
+++ b/config/gulp/state-data.json
@@ -346,7 +346,7 @@
       "more_info_link": "https://sos.iowa.gov/elections/voterinformation/voterregistration.html",
       "ip_deadline": "Tuesday, November 3, 2020",
       "online_deadline": "Saturday, October 24, 2020",
-      "mail_deadline": "Monday, October 19, 2020"
+      "mail_deadline2": "Saturday, October 24, 2020"
     },
     "spanish": {
       "registration_link": "https://mymvd.iowadot.gov/Account/Login?ReturnUrl=%2fVoterRegistration",
@@ -355,7 +355,7 @@
       "more_info_link_english_only": "true",
       "ip_deadline": "martes 3 de noviembre 2020",
       "online_deadline": "sábado 24 de octubre 2020",
-      "mail_deadline": "lunes 19 de octubre 2020"
+      "mail_deadline2": "sábado 24 de octubre 2020"
     }
   },
   "Kansas": {


### PR DESCRIPTION
Changed mail in registration date to Sat. Oct. 24 in English and Spanish; Also changed from postmarked to received by