### PR TITLE
Removed Crazy Egg code from some states

### DIFF
--- a/config/gulp/state-data.json
+++ b/config/gulp/state-data.json
@@ -98,7 +98,7 @@
     "english": {
       "registration_link": "https://registertovote.ca.gov/",
       "more_info_link": "https://www.sos.ca.gov/elections/voting-resources/voting-california/registering-vote/",
-      "crazyegg": "false",
+      "crazyegg": "true",
       "ip_deadline": "Tuesday, November 3, 2020",
       "online_deadline": "Monday, October 19, 2020",
       "mail_deadline": "Monday, October 19, 2020"
@@ -106,7 +106,7 @@
     "spanish": {
       "registration_link": "https://registertovote.ca.gov/es-mx",
       "more_info_link": "https://www.sos.ca.gov/elections/voting-resources/voting-california/spanish/registering-vote/",
-      "crazyegg": "false",
+      "crazyegg": "true",
       "ip_deadline": "martes 3 de noviembre 2020",
       "online_deadline": "lunes 19 de octubre 2020",
       "mail_deadline": "lunes 19 de octubre 2020"
@@ -175,7 +175,6 @@
     }
   },
   "District of Columbia": {
-    "crazyegg": "true",
     "state_name": "District of Columbia",
     "state_abbreviation": "dc",
     "registration_type": "by-mail",
@@ -208,7 +207,6 @@
       "registration_link_spanish_selection": "true",
       "more_info_link": "https://registertovoteflorida.gov/home",
       "more_info_link_spanish_selection": "true",
-      "crazyegg": "false",
       "ip_deadline": "lunes 5 de octubre 2020",
       "online_deadline": "lunes 5 de octubre 2020",
       "mail_deadline2": "lunes 5 de octubre 2020"
@@ -675,7 +673,6 @@
     "english": {
       "registration_link": "https://dmv.ny.gov/more-info/electronic-voter-registration-application",
       "more_info_link": "https://www.elections.ny.gov/votingregister.html",
-      "crazyegg": "true",
       "ip_deadline": "Friday, October 9, 2020",
       "online_deadline": "Friday, October 9, 2020",
       "mail_deadline": "Friday, October 9, 2020"


### PR DESCRIPTION
Running a new crazy egg report. Only want it on the home pages, California and Texas (both English and Spanish pages). I removed the crazy egg code from the other states