### PR TITLE
Update Maine mail deadline to 10/19 (from 10/13)

### DIFF
--- a/config/gulp/state-data.json
+++ b/config/gulp/state-data.json
@@ -485,14 +485,14 @@
     "english": {
       "more_info_link": "https://www.maine.gov/sos/cec/elec/voter-info/voterguide.html",
       "ip_deadline": "Tuesday, November 3, 2020",
-      "mail_deadline2": "Tuesday, October 13, 2020",
+      "mail_deadline2": "Tuesday, October 19, 2020",
       "confirm_registration": "https://www.maine.gov/sos/cec/elec/data/index.html"
     },
     "spanish": {
       "more_info_link": "https://www.maine.gov/sos/cec/elec/voter-info/voterguide.html",
       "more_info_link_english_only": "true",
       "ip_deadline": "martes 3 de noviembre 2020",
-      "mail_deadline2": "martes 13 de octubre 2020",
+      "mail_deadline2": "martes 19 de octubre 2020",
       "confirm_registration": "https://www.maine.gov/sos/cec/elec/data/index.html",
       "confirm_registration_english_only": "true"
     }


### PR DESCRIPTION
The mail deadline for registration in Maine seems to be out of date. It would normally be 10/13 this year, but IIUC the governor pushed it back to 10/19 due to COVID (info via VoteAmerica and FiveThirtyEight):

https://www.maine.gov/governor/mills/news/governor-mills-signs-executive-order-facilitate-voting-protect-health-voters-election