### PR TITLE
VOTE-140 Remove langcode subtags from html output

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,7 @@
 {{ $translation := ( index $.Site.Data.translations .Site.Language.Lang ) }}
 
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" dir="{{ .Site.Params.language_direction }}">
+<html lang="{{ .Site.Language.Lang | replaceRE "-[a-z]+" "" }}" dir="{{ .Site.Params.language_direction }}">
 <head>
 
 <!-- Google Tag Manager -->

--- a/layouts/partials/language-switcher.html
+++ b/layouts/partials/language-switcher.html
@@ -4,7 +4,7 @@
   <label for="language-switcher" class="usa-label usa-label--language">{{ replace .Site.Params.select_language "%dropdown-list%" "" }}</label>
   <select class="usa-select usa-select--language" name="language-switcher" id="language-switcher" onchange="window.location=this.value;">
     {{ range $.Site.Home.AllTranslations }}
-    <option value="{{ .RelPermalink }}{{ if not ($.IsHome) }}{{ .Site.Params.register_path }}/{{ $state }}{{ end }}"{{ if eq $currentLang .Language.LanguageName }} selected="selected"{{ end }}>
+    <option lang="{{ .Language.Lang | replaceRE "-[a-z]+" "" }}" value="{{ .RelPermalink }}{{ if not ($.IsHome) }}{{ .Site.Params.register_path }}/{{ $state }}{{ end }}"{{ if eq $currentLang .Language.LanguageName }} selected="selected"{{ end }}>
       {{ .Language.LanguageName }} {{ if not (eq .Site.Params.english_languageName "") }}({{ .Site.Params.english_languageName }}){{ end }}
     </option>
     {{ end }}

--- a/layouts/partials/language-switcher1.html
+++ b/layouts/partials/language-switcher1.html
@@ -4,7 +4,7 @@
   <label for="language-switcher1" class="usa-label usa-label--language">{{ replace .Site.Params.select_language "%dropdown-list%" "" }}</label>
   <select class="usa-select usa-select--language" name="language-switcher1" id="language-switcher1" onchange="window.location=this.value;">
     {{ range $.Site.Home.AllTranslations }}
-    <option value="{{ .RelPermalink }}{{ if not ($.IsHome) }}{{ .Site.Params.register_path }}/{{ $state }}{{ end }}"{{ if eq $currentLang .Language.LanguageName }} selected="selected"{{ end }}>
+    <option lang="{{ .Language.Lang | replaceRE "-[a-z]+" "" }}" value="{{ .RelPermalink }}{{ if not ($.IsHome) }}{{ .Site.Params.register_path }}/{{ $state }}{{ end }}"{{ if eq $currentLang .Language.LanguageName }} selected="selected"{{ end }}>
       {{ .Language.LanguageName }} {{ if not (eq .Site.Params.english_languageName "") }}({{ .Site.Params.english_languageName }}){{ end }}
     </option>{{ end }}
   </select>


### PR DESCRIPTION
Our Accessibility & Compliance Lead has advised that language subtags be removed for output on the html tag and that our language switcher should include langcodes.