### PR TITLE
vote-790 -> fix internal links test 

### DIFF
--- a/cypress/e2e/internalLinks/internal-link-validator.cy.js
+++ b/cypress/e2e/internalLinks/internal-link-validator.cy.js
@@ -1,18 +1,47 @@
 /// <reference types="Cypress" />
 
-describe("Internal Link Validator Test", () => {
-it('Validate internal links', () => {
-  cy.getUrlsEnglish().then($urls => {
-    $urls.forEach(url => {
-      cy.visit(url).then(() => {
+const allPages = require("../../fixtures/site-pages.json");
+
+describe("External Link Validator Test", () => {
+  const baseURL = Cypress.env("base_url")
+    ? Cypress.env("base_url")
+    : "http://localhost:1313";
+
+  const singlePage =
+    Cypress.env("name") && Cypress.env("route")
+      ? [
+          {
+            name: Cypress.env("name"),
+            route: Cypress.env("route"),
+          },
+        ]
+      : null;
+  const pages = singlePage !== null ? singlePage : allPages;
+  pages.forEach((page) => {
+    it( 
+      `${page.name === "" ? "home" : page.name}`,
+      () =>
+        Cypress.env("retries") === true
+          ? {
+              retries: {
+                runMode: 2,
+              },
+            }
+          : {},
+      () => {
+        cy.visit({
+          url: baseURL + page.route,
+        });
         cy.get("a[href^='/']").each(link => {
-          cy.request(link.prop('href')).then(link => {
-            expect(link.status).to.eq(200)
-          })
+            cy.request({
+              url: link.prop('href'),
+              failOnStatusCode: false
+            }).then((response) => {
+              expect(response.status).to.eq(200)
+            })
         })
-    })
-  })
-})
-})
+      }
+    );
+  });    
 });
 


### PR DESCRIPTION
link to ticket -> https://bixal-projects.atlassian.net/browse/VOTE-790

This Pr will update the internal links test... currently it is failing in the pipeline.  After looking into it more the test was running through the whole sitemap and just timing out after running for like 15 mins.  I think that there might have been a mistake in adding the sitemap in testing a few things and this will fix that and should now run in the pipeline quicker overall. 

how to test:

- Pull down the branch 
- run `npm run start`
- spilt terminal 
- run `npm run cy:open` and check that the internal links test is passing 
- also run `npm run cy:links` to check that the headless is running and passing as well. 