### PR TITLE
Vote-1364 - Language Switcher Test Update

### DIFF
--- a/cypress/e2e/tests/language-switcher.cy.js
+++ b/cypress/e2e/tests/language-switcher.cy.js
@@ -16,6 +16,8 @@ describe('Test Language Switcher Function', () => {
       cy.get('[data-test="language-button"]').click().get('[data-test="language-switcher"]').then(options =>
         cy.get(options[0]).find('li').then(li => {
           cy.get(li[1]).click()
+           // eslint-disable-next-line cypress/no-unnecessary-waiting
+           cy.wait(3000)
           cy.get('[data-test="vote-logo"]').should('contain', 'Vote.gov en Español')
         })
         )
@@ -81,6 +83,18 @@ describe('Test Language Switcher Function', () => {
         )
     })
 
+    it(`test portuguese ${page}`, () => {
+      cy.visit(page)
+      cy.get('[data-test="language-button"]').click().get('[data-test="language-switcher"]').then(options =>
+        cy.get(options[0]).find('li').then(li => {
+          cy.get(li[9]).click()
+          // eslint-disable-next-line cypress/no-unnecessary-waiting
+          cy.wait(3000)
+          cy.get('[data-test="vote-logo"]').should('contain', 'Vote.gov em Português')
+        })
+        )
+    })
+
     // it(`test navajo ${page}`, () => {
     //   cy.visit(page)
     //   cy.get('[data-test="language-button"]').click().get('[data-test="language-switcher"]').then(options =>
@@ -95,7 +109,7 @@ describe('Test Language Switcher Function', () => {
       cy.visit(page)
       cy.get('[data-test="language-button"]').click().get('[data-test="language-switcher"]').then(options =>
         cy.get(options[0]).find('li').then(li => {
-          cy.get(li[9]).click()
+          cy.get(li[10]).click()
           cy.get('[data-test="vote-logo"]').should('contain', 'Vote.gov sa Tagalog')
         })
         )
@@ -105,7 +119,7 @@ describe('Test Language Switcher Function', () => {
       cy.visit(page)
       cy.get('[data-test="language-button"]').click().get('[data-test="language-switcher"]').then(options =>
         cy.get(options[0]).find('li').then(li => {
-          cy.get(li[10]).click()
+          cy.get(li[11]).click()
           cy.get('[data-test="vote-logo"]').should('contain', 'Vote.gov bằng Tiếng Việt')
         })
         )
@@ -115,7 +129,7 @@ describe('Test Language Switcher Function', () => {
     cy.visit(page)
     cy.get('[data-test="language-button"]').click().get('[data-test="language-switcher"]').then(options =>
       cy.get(options[0]).find('li').then(li => {
-        cy.get(li[11]).click()
+        cy.get(li[12]).click()
         cy.get('[data-test="vote-logo"]').should('contain', 'Vote.gov Akuzipigestun')
       })
       )

--- a/cypress/e2e/tests/language-switcher.cy.js
+++ b/cypress/e2e/tests/language-switcher.cy.js
@@ -15,9 +15,8 @@ describe('Test Language Switcher Function', () => {
       cy.visit(page)
       cy.get('[data-test="language-button"]').click().get('[data-test="language-switcher"]').then(options =>
         cy.get(options[0]).find('li').then(li => {
-          cy.get(li[1]).click()
            // eslint-disable-next-line cypress/no-unnecessary-waiting
-           cy.wait(3000)
+          cy.get(li[1]).wait(3000).click()
           cy.get('[data-test="vote-logo"]').should('contain', 'Vote.gov en Español')
         })
         )


### PR DESCRIPTION
This PR will add Portuguese to the language switcher test

to test:

1.  pull down branch 
2. run `npm run start`
3. spilt termnail 
4. run `npm run cy:test` and verify that tests are passing 

