### PR TITLE
VOTE-1425 Remove mail deadlines for U.S. Virgin Islands

### DIFF
--- a/content/hi/register/vi.md
+++ b/content/hi/register/vi.md
@@ -10,6 +10,5 @@ hp_link = "https://www.vivote.gov/voters/register-to-vote/"
 more_info_link = "https://www.vivote.gov/voters/register-to-vote/"
 confirm_registration_link = "https://www.vivote.gov/voters/voter-lookup/"
 default_ip_deadline = "मतदान दिवस से 30 दिन पहले"
-default_mail_postmarked_deadline = "मतदान दिवस से 30 दिन पहले पोस्टमार्क होना चाहिए"
 
 +++

--- a/content/km/register/vi.md
+++ b/content/km/register/vi.md
@@ -10,6 +10,5 @@ hp_link = "https://www.vivote.gov/voters/register-to-vote/"
 more_info_link = "https://www.vivote.gov/voters/register-to-vote/"
 confirm_registration_link = "https://www.vivote.gov/voters/voter-lookup/"
 default_ip_deadline = "30 ថ្ងៃមុនថ្ងៃបោះឆ្នោត"
-default_mail_postmarked_deadline = "ត្រូវតែបានបោះតែមប្រៃសណីយ៍ 30 ថ្ងៃមុនថ្ងៃបោះឆ្នោត"
 
 +++

--- a/content/ko/register/vi.md
+++ b/content/ko/register/vi.md
@@ -10,6 +10,5 @@ hp_link = "https://www.vivote.gov/voters/register-to-vote/"
 more_info_link = "https://www.vivote.gov/voters/register-to-vote/"
 confirm_registration_link = "https://www.vivote.gov/voters/voter-lookup/"
 default_ip_deadline = "선거일 30일 전까지"
-default_mail_postmarked_deadline = "반드시 선거일 30일 전까지 일자로 소인이 날인되어야 합니다."
 
 +++

--- a/content/tl/register/vi.md
+++ b/content/tl/register/vi.md
@@ -10,6 +10,5 @@ hp_link = "https://www.vivote.gov/voters/register-to-vote/"
 more_info_link = "https://www.vivote.gov/voters/register-to-vote/"
 confirm_registration_link = "https://www.vivote.gov/voters/voter-lookup/"
 default_ip_deadline = "30 araw bago ang Araw ng Eleksyon"
-default_mail_postmarked_deadline = "Dapat na naka-postmark 30 araw bago ang Araw ng Eleksyon"
 
 +++

--- a/content/vi/register/vi.md
+++ b/content/vi/register/vi.md
@@ -10,6 +10,5 @@ hp_link = "https://www.vivote.gov/voters/register-to-vote/"
 more_info_link = "https://www.vivote.gov/voters/register-to-vote/"
 confirm_registration_link = "https://www.vivote.gov/voters/voter-lookup/"
 default_ip_deadline = "30 ngày trước Ngày Bầu Cử"
-default_mail_postmarked_deadline = "Phải được đóng dấu bưu điện 30 ngày trước Ngày Bầu Cử"
 
 +++

--- a/content/ypk/register/vi.md
+++ b/content/ypk/register/vi.md
@@ -10,6 +10,5 @@ hp_link = "https://www.vivote.gov/voters/register-to-vote/"
 more_info_link = "https://www.vivote.gov/voters/register-to-vote/"
 confirm_registration_link = "https://www.vivote.gov/voters/voter-lookup/"
 default_ip_deadline = "30 aghneq Nakmikivigem sivunganeng."
-default_mail_postmarked_deadline = "30 aghneq Nakmikivigem sivunganeng."
 
 +++

--- a/data/translations/hi/state-data.json
+++ b/data/translations/hi/state-data.json
@@ -240,8 +240,7 @@
     "default_mail_postmarked_deadline": "मतदान दिवस से 22 दिन पहले पोस्टमार्क होना चाहिए"
   },
   "vi": {
-    "default_ip_deadline": "मतदान दिवस से 30 दिन पहले",
-    "default_mail_postmarked_deadline": "मतदान दिवस से 30 दिन पहले पोस्टमार्क होना चाहिए"
+    "default_ip_deadline": "मतदान दिवस से 30 दिन पहले"
   },
   "wa": {
     "default_ip_deadline": "मतदान दिवस तक और मतदान के दिन भी ",

--- a/data/translations/km/state-data.json
+++ b/data/translations/km/state-data.json
@@ -240,8 +240,7 @@
     "default_mail_postmarked_deadline": "ត្រូវតែបានបោះតែមប្រៃសណីយ៍ 22 ថ្ងៃមុនថ្ងៃបោះឆ្នោត"
   },
   "vi": {
-    "default_ip_deadline": "30 ថ្ងៃមុនថ្ងៃបោះឆ្នោត",
-    "default_mail_postmarked_deadline": "ត្រូវតែបានបោះតែមប្រៃសណីយ៍ 30 ថ្ងៃមុនថ្ងៃបោះឆ្នោត"
+    "default_ip_deadline": "30 ថ្ងៃមុនថ្ងៃបោះឆ្នោត"
   },
   "wa": {
     "default_ip_deadline": "អាចរកបានពីឥឡូវរហូតដល់ថ្ងៃបោះឆ្នោត",

--- a/data/translations/ko/state-data.json
+++ b/data/translations/ko/state-data.json
@@ -240,8 +240,7 @@
     "default_mail_postmarked_deadline": "반드시 선거일 22일 전까지 일자로 소인이 날인되어야 합니다."
   },
   "vi": {
-    "default_ip_deadline": "선거일 30일 전까지",
-    "default_mail_postmarked_deadline": "반드시 선거일 30일 전까지 일자로 소인이 날인되어야 합니다."
+    "default_ip_deadline": "선거일 30일 전까지"
   },
   "wa": {
     "default_ip_deadline": "선거당일까지 등록이 가능합니다.",

--- a/data/translations/tl/state-data.json
+++ b/data/translations/tl/state-data.json
@@ -240,8 +240,7 @@
     "default_mail_postmarked_deadline": "Dapat na naka-postmark  22 araw bago ang Araw ng Eleksyon"
   },
   "vi": {
-    "default_ip_deadline": "30 araw bago ang Araw ng Eleksyon",
-    "default_mail_postmarked_deadline": "Dapat na naka-postmark 30 araw bago ang Araw ng Eleksyon"
+    "default_ip_deadline": "30 araw bago ang Araw ng Eleksyon"
   },
   "wa": {
     "default_ip_deadline": "Maari hanggang at kasama sa  Araw ng Eleksyon",

--- a/data/translations/vi/state-data.json
+++ b/data/translations/vi/state-data.json
@@ -239,8 +239,7 @@
     "default_mail_postmarked_deadline": "Phải được đóng dấu bưu điện 22 ngày trước Ngày Bầu Cử"
   },
   "vi": {
-    "default_ip_deadline": "30 ngày trước Ngày Bầu Cử",
-    "default_mail_postmarked_deadline": "Phải được đóng dấu bưu điện 30 ngày trước Ngày Bầu Cử"
+    "default_ip_deadline": "30 ngày trước Ngày Bầu Cử"
   },
   "wa": {
     "default_ip_deadline": "Có sẵn cho đến và bao gồm cả vào ngày Bầu Cử",

--- a/data/translations/ypk/state-data.json
+++ b/data/translations/ypk/state-data.json
@@ -240,8 +240,7 @@
     "default_mail_postmarked_deadline": "Tuyumayaghqaguq 22 aghneq Nakmikivigem sivunganeng."
   },
   "vi": {
-    "default_ip_deadline": "30 aghneq Nakmikivigem sivunganeng.",
-    "default_mail_postmarked_deadline": "30 aghneq Nakmikivigem sivunganeng."
+    "default_ip_deadline": "30 aghneq Nakmikivigem sivunganeng."
   },
   "wa": {
     "default_ip_deadline": "Piivngallequq Nakmikivigem kenlenganun aghneghanillu.",


### PR DESCRIPTION
Removed mail deadlines from the U.S. Virgin Islands pages.
https://bixal-projects.atlassian.net/browse/VOTE-1425