### PR TITLE
fix failing external link tests

### DIFF
--- a/cypress/e2e/externalLinks/english-external-links-validator.cy.js
+++ b/cypress/e2e/externalLinks/english-external-links-validator.cy.js
@@ -52,7 +52,7 @@ describe("External Link Validator Test", () => {
         cy.visit({
           url: baseURL + page.route,
         });
-        cy.get("div[role='main'] a[href^='https://']").each(link => {
+        cy.get("a[href^='https://']").each(link => {
           if (excludedlinks.indexOf(link.prop('href')) == -1) {
             cy.request({
               url: link.prop('href'),

--- a/cypress/e2e/externalLinks/english-external-links-validator.cy.js
+++ b/cypress/e2e/externalLinks/english-external-links-validator.cy.js
@@ -52,7 +52,7 @@ describe("External Link Validator Test", () => {
         cy.visit({
           url: baseURL + page.route,
         });
-        cy.get("a[href^='https://']").each(link => {
+        cy.get("main a[href^='https://']").each(link => {
           if (excludedlinks.indexOf(link.prop('href')) == -1) {
             cy.request({
               url: link.prop('href'),

--- a/cypress/e2e/externalLinks/spanish-external-links-validator.cy.js
+++ b/cypress/e2e/externalLinks/spanish-external-links-validator.cy.js
@@ -51,7 +51,7 @@ describe("Spanish External Link Validator Test", () => {
         cy.visit({
           url: baseURL + page.route,
         });
-        cy.get("div[role='main'] a[href^='https://']").each(link => {
+        cy.get("a[href^='https://']").each(link => {
           if (excludedlinks.indexOf(link.prop('href')) == -1) {
             cy.request({
               url: link.prop('href'),

--- a/cypress/e2e/externalLinks/spanish-external-links-validator.cy.js
+++ b/cypress/e2e/externalLinks/spanish-external-links-validator.cy.js
@@ -51,7 +51,7 @@ describe("Spanish External Link Validator Test", () => {
         cy.visit({
           url: baseURL + page.route,
         });
-        cy.get("a[href^='https://']").each(link => {
+        cy.get("main a[href^='https://']").each(link => {
           if (excludedlinks.indexOf(link.prop('href')) == -1) {
             cy.request({
               url: link.prop('href'),


### PR DESCRIPTION
Fixed the locator used to identify external links in the page.

To test this, checkout this branch and run npm run cy:proofer

Guam and Virginia will fail. There is a defect to resolve this issue (https://bixal-projects.atlassian.net/jira/software/c/projects/VOTE/issues/VOTE-1448)

Verify other tests pass