### PR TITLE
VOTE-1439 add robots.txt file

### DIFF
--- a/config/_default/config.json
+++ b/config/_default/config.json
@@ -1,6 +1,7 @@
 {
   "defaultContentLanguage": "en",
   "enableGitInfo": "true",
+  "enableRobotsTXT": true,
   "publishDir": "tmp/public",
   "title": "Voter Registration",
   "baseURL": "",

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,7 @@
+{{- $envURL := ( index .Site.Params.envURL (os.Getenv "BRANCH") ) -}}
+User-agent: *
+{{ if eq $envURL "master" -}}
+Sitemap: https://vote.gov/sitemap.xml
+{{- else -}}
+Disallow: /
+{{- end }}


### PR DESCRIPTION
https://bixal-projects.atlassian.net/browse/VOTE-1439

This PR adds the robots.txt file to Hugo. For production branch (`master`) it will add the sitemap location and allow all pages. For all other branches it will exclude the sitemap link and disallow all pages.