### PR TITLE
Vote-1416 -> NJ Tagalog mail deadline property update

### DIFF
--- a/content/tl/register/nj.md
+++ b/content/tl/register/nj.md
@@ -11,7 +11,7 @@ registration_link = "https://voter.svrs.nj.gov/register"
 more_info_link = "https://nj.gov/state/elections/voter-registration.shtml"
 confirm_registration_link = "https://voter.svrs.nj.gov/registration-check"
 default_online_deadline = "21 araw bago ang Araw ng Eleksyon"
-default_mail_postmarked_deadline = "Dapat matanggap 21 araw bago ang Araw ng Eleksyon"
+default_mail_received_deadline = "Dapat matanggap 21 araw bago ang Araw ng Eleksyon"
 default_ip_deadline = "21 araw bago ang Araw ng Eleksyon"
 
 +++

--- a/data/translations/tl/state-data.json
+++ b/data/translations/tl/state-data.json
@@ -156,7 +156,7 @@
   },
   "nj": {
     "default_online_deadline": "21 araw bago ang Araw ng Eleksyon",
-    "default_mail_postmarked_deadline": "Dapat matanggap 21 araw bago ang Araw ng Eleksyon",
+    "default_mail_received_deadline": "Dapat matanggap 21 araw bago ang Araw ng Eleksyon",
     "default_ip_deadline": "21 araw bago ang Araw ng Eleksyon"
   },
   "nm": {


### PR DESCRIPTION
This Pr will update the deadline property to be 'received' over 'postmarked'

link to ticket [Vote-1416](https://bixal-projects.atlassian.net/jira/software/c/projects/VOTE/boards/254?modal=detail&selectedIssue=VOTE-1416&assignee=611272e0eb7aef00694b8a97)

to test:

1. check changed files and ensure that received has been replaced over postmarked. 
2. start local and visit `http://localhost:1313/tl/register/nj/` to verify no visual regressions