### PR TITLE
Add Montana link causing fail 

### DIFF
--- a/cypress/e2e/excludedLinks/excluded-links-english.cy.js
+++ b/cypress/e2e/excludedLinks/excluded-links-english.cy.js
@@ -1,6 +1,6 @@
 /// <reference types="Cypress" />
 
-// this test will run out of the pipeline and will be a manaul test each sprint 
+// this test will run out of the pipeline and will be a manual test each sprint 
 
 const english = require("../../fixtures/excluded-links-english.json");
 

--- a/cypress/e2e/externalLinks/english-external-links-validator.cy.js
+++ b/cypress/e2e/externalLinks/english-external-links-validator.cy.js
@@ -16,10 +16,11 @@ const excludedlinks = [
   'https://vote.sos.ri.gov/Voter/RegisterToVote?ref=voteusa_en',
   'https://vote.sos.ri.gov/Home/UpdateVoterRecord?ActiveFlag=0&?ref=voteusa_en',
   'https://my.arizona.vote/WhereToVote.aspx?s=individual&?ref=voteusa_en',
+  'https://sosmt.gov/elections/vote/?ref=voteusa_en',
   // sc links
   'https://vrems.scvotes.sc.gov/Voter/Login?ref=voteusa_en',
   'https://scvotes.gov/voters/register-to-vote/?ref=voteusa_en',
-  'https://info.scvotes.sc.gov/eng/ovr/start.aspx?ref=voteusa_en'
+  'https://info.scvotes.sc.gov/eng/ovr/start.aspx?ref=voteusa_en',
 ];
 
 describe("External Link Validator Test", () => {

--- a/cypress/e2e/externalLinks/spanish-external-links-validator.cy.js
+++ b/cypress/e2e/externalLinks/spanish-external-links-validator.cy.js
@@ -15,6 +15,7 @@ const excludedlinks = [
   'https://vote.sos.ri.gov/VoterSpanish/RegisterToVote?ref=voteusa_es',
   'https://vote.sos.ri.gov/HomeSpanish/UpdateVoterRecord?ActiveFlag=0&?ref=voteusa_es',
   'https://my.arizona.vote/WhereToVote.aspx?s=individual&?ref=voteusa_es',
+  "https://sosmt.gov/elections/vote/?ref=voteusa_es",
     // sc links
   'https://vrems.scvotes.sc.gov/Voter/Login?ref=voteusa_es',
   'https://scvotes.gov/voters/register-to-vote/?ref=voteusa_es',

--- a/cypress/fixtures/excluded-links-english.json
+++ b/cypress/fixtures/excluded-links-english.json
@@ -12,7 +12,7 @@
   "https://vrems.scvotes.sc.gov/Voter/Login?ref=voteusa_en",
   "https://scvotes.gov/voters/register-to-vote/?ref=voteusa_en",
   "https://info.scvotes.sc.gov/eng/ovr/start.aspx?ref=voteusa_en",
-  "https://my.arizona.vote/WhereToVote.aspx?s=individual&?ref=voteusa_en"
-
+  "https://my.arizona.vote/WhereToVote.aspx?s=individual&?ref=voteusa_en",
+  "https://sosmt.gov/elections/vote/?ref=voteusa_en"
   
 ]   

--- a/cypress/fixtures/excluded-links-spanish.json
+++ b/cypress/fixtures/excluded-links-spanish.json
@@ -11,5 +11,7 @@
   "https://vrems.scvotes.sc.gov/Voter/Login?ref=voteusa_es",
   "https://scvotes.gov/voters/register-to-vote/?ref=voteusa_es",
   "https://info.scvotes.sc.gov/eng/ovr/start.aspx?ref=voteusa_es",
-  "https://my.arizona.vote/WhereToVote.aspx?s=individual&?ref=voteusa_es"
+  "https://my.arizona.vote/WhereToVote.aspx?s=individual&?ref=voteusa_es",
+  "https://sosmt.gov/elections/vote/?ref=voteusa_es"
+  
 ]


### PR DESCRIPTION
This Pr will add the Montana link that is giving a 403 error in the external link validator test.

to test 

1. pull down branch 
2. start local 
3. spilt terminal 
4. run `npm run cy:links` and verify links are passing 