### PR TITLE
VOTE-1442 Change month translation strings from numbers to names

### DIFF
--- a/data/translations/tl/months.json
+++ b/data/translations/tl/months.json
@@ -1,14 +1,14 @@
 {
-  "1": "Enero",
-  "2": "Pebrero",
-  "3": "Marso",
-  "4": "April",
-  "5": "Mayo",
-  "6": "Hunyo",
-  "7": "Hulyo",
-  "8": "Agosto",
-  "9": "Septiyembre",
-  "10": "Oktubre",
-  "11": "Nobyembre",
-  "12": "Disyembre"
+  "january": "Enero",
+  "february": "Pebrero",
+  "march": "Marso",
+  "april": "April",
+  "may": "Mayo",
+  "june": "Hunyo",
+  "july": "Hulyo",
+  "august": "Agosto",
+  "september": "Septiyembre",
+  "october": "Oktubre",
+  "november": "Nobyembre",
+  "december": "Disyembre"
 }


### PR DESCRIPTION
https://bixal-projects.atlassian.net/jira/software/c/projects/VOTE/boards/254?modal=detail&selectedIssue=VOTE-1442&assignee=62c492177273faf658f0d675

The month names in Tagalog were missing because the translation strings were incorrect.