### PR TITLE
vote-87 - added search block to ht translation

### DIFF
--- a/data/translations/ht/homepage.json
+++ b/data/translations/ht/homepage.json
@@ -25,6 +25,6 @@
   "registered_links__absentee": "Vòt pa korespondans (ann Anglè)",
   "registered_links__absentee_url": "https://www.usa.gov/absentee-voting",
   "section_banner": "Sit entènèt ofisyèl gouvènman an",
-  "search_affiliate_translated": true,
+  "search_affiliate_translated": false,
   "search_placeholder": "Fè rechèch sou vote.gov"
 }

--- a/data/translations/ht/homepage.json
+++ b/data/translations/ht/homepage.json
@@ -24,5 +24,7 @@
   "registered_links__process_url": "https://www.usa.gov/election",
   "registered_links__absentee": "Vòt pa korespondans (ann Anglè)",
   "registered_links__absentee_url": "https://www.usa.gov/absentee-voting",
-  "section_banner": "Sit entènèt ofisyèl gouvènman an"
+  "section_banner": "Sit entènèt ofisyèl gouvènman an",
+  "search_affiliate_translated": true,
+  "search_placeholder": "Fè rechèch sou vote.gov"
 }


### PR DESCRIPTION
ticket -> [Vote-87](https://cm-jira.usa.gov/secure/RapidBoard.jspa?rapidView=4046&projectKey=VOTE&view=detail&selectedIssue=VOTE-36&quickFilter=23166)

purpose -> ht translation was missing the search vote.gov block 

testing:

1. pull down branch 
2. run `npm run start`
3. visit `localhost:1313` and verify that search block is present on ht translation 