### PR TITLE
BUG: Update Github actions with new node set up 

### DIFF
--- a/.github/workflows/cypress-axe-workflow.yml
+++ b/.github/workflows/cypress-axe-workflow.yml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@v2
         
       - name: Install node.js.
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Install NPM dependencies.
         run: npm install

--- a/.github/workflows/cypress-external-links-cron-workflow.yml
+++ b/.github/workflows/cypress-external-links-cron-workflow.yml
@@ -20,9 +20,9 @@ jobs:
           ref: master
 
       - name: Install node.js.
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Install NPM dependencies.
         run: npm install

--- a/.github/workflows/cypress-functional-workflow.yml
+++ b/.github/workflows/cypress-functional-workflow.yml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@v2
         
       - name: Install node.js.
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Install NPM dependencies.
         run: npm install

--- a/.github/workflows/cypress-links-workflow.yml
+++ b/.github/workflows/cypress-links-workflow.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install node.js.
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '18'
 

--- a/cypress/e2e/tests/footer.cy.js
+++ b/cypress/e2e/tests/footer.cy.js
@@ -6,7 +6,7 @@ describe('Test the site contact/identifier footer on site',() => {
   })
 
   it("Validate that contact component is present", () =>{
-    cy.get('[data-test="footer-contact"]').should('not.be.visible')
+    cy.get('[data-test="footer-contact"]').should('be.visible')
   })
 
   it("Validate that the identifier links are working as expected", () =>{

--- a/cypress/e2e/tests/footer.cy.js
+++ b/cypress/e2e/tests/footer.cy.js
@@ -6,7 +6,7 @@ describe('Test the site contact/identifier footer on site',() => {
   })
 
   it("Validate that contact component is present", () =>{
-    cy.get('[data-test="footer-contact"]').should('be.visible')
+    cy.get('[data-test="footer-contact"]').should('not.be.visible')
   })
 
   it("Validate that the identifier links are working as expected", () =>{


### PR DESCRIPTION
This PR will update the node version to 18 since node16 has hit the end of life, and the node set up version from `v2` to `v3` 
note: the updates have to be in the default branch which is staging before we can check that the fix is working.  once this has been merged in we can check that this fix works and if not will work to ensure the correct fix is done. 

below is a screenshot of the update and a link to the changelog is [here](https://github.com/actions/setup-node/releases?page=2) look for the version 3 update

<img width="1450" alt="Screenshot 2023-09-14 at 1 25 11 PM" src="https://github.com/usagov/vote-gov/assets/88721460/292aa3e9-744e-4ec0-9889-2c3e956a2985">
