### PR TITLE
VOTE-314: Updated checkout action from version 2 to 4

### DIFF
--- a/.github/workflows/cypress-axe-workflow.yml
+++ b/.github/workflows/cypress-axe-workflow.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout source.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         
       - name: Install node.js.
         uses: actions/setup-node@v3

--- a/.github/workflows/cypress-external-links-cron-workflow.yml
+++ b/.github/workflows/cypress-external-links-cron-workflow.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code on main.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with: 
           ref: master
 

--- a/.github/workflows/cypress-functional-workflow.yml
+++ b/.github/workflows/cypress-functional-workflow.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout source.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         
       - name: Install node.js.
         uses: actions/setup-node@v3

--- a/.github/workflows/cypress-links-workflow.yml
+++ b/.github/workflows/cypress-links-workflow.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout source.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install node.js.
         uses: actions/setup-node@v3


### PR DESCRIPTION
Ticket: [Vote-314](https://cm-jira.usa.gov/browse/VOTE-314)

This Pr will update the checkout action from version 2 to version 4 and remove the error of running node 12 from the actions run.  This will help ensure that we are using the most up to date.

link to [Change Log](https://github.com/actions/checkout/blob/main/CHANGELOG.md)

The error we were getting:

<img width="1171" alt="Screenshot 2023-09-18 at 10 33 06 AM" src="https://github.com/usagov/vote-gov/assets/88721460/fecf5148-afac-440c-b5ce-67dc69a7c717">


Link to new run with no error: https://github.com/usagov/vote-gov/actions/runs/6223971737
