### PR TITLE
Vote-491: added override for menu font to match rest of site.

### DIFF
--- a/assets/styles/component/language-switcher.scss
+++ b/assets/styles/component/language-switcher.scss
@@ -25,6 +25,10 @@
 .usa-language__submenu-item {
   padding: 8px;
   border: unset;
+  
+  * {
+    font-family: "Source Sans Pro Web", "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+  }
 }
 
 .switcher-desktop {


### PR DESCRIPTION
Ticket: [Vote-491](https://cm-jira.usa.gov/browse/VOTE-491)
Purpose: Strings within Navajo were not getting formatted correctly in the language selector 
Testing: Visit [Preview](https://cg-9e8debaf-b030-4825-a43c-cb2bc850c96c.sites.pages.cloud.gov/preview/usagov/vote-gov/bug/vote-491-nv-bug/nv/) and verify that the language drop-down looks as expected and does not have any errors with strings 