### PR TITLE
Vote-476: Remove Guam Links 

### DIFF
--- a/cypress/fixtures/site-pages.json
+++ b/cypress/fixtures/site-pages.json
@@ -66,11 +66,6 @@
   },
 
   {
-    "name": "Guam",
-    "route": "/register/gu/"
-  },
-
-  {
     "name": "Hawaii",
     "route": "/register/hi/"
   },
@@ -348,11 +343,6 @@
   {
     "name": "Georgia",
     "route": "/es/registrar/ga/"
-  },
-
-  {
-    "name": "Guam",
-    "route": "/es/registrar/gu/"
   },
 
   {


### PR DESCRIPTION
Ticket: [Vote-476](https://cm-jira.usa.gov/browse/VOTE-476)
Purpose:  Guam links are giving an unresponsive status at times, since the links are the current ones we need to leave them but will be skipping them for now and will add them back at a later time.
Testing:  Pull down branch and run `npm run start` spilt terminal and run `npm run cy:proofer` and check that Guam does not run. Also view changed files and ensure that Guam has been removed twice... once for English and the other for Spanish.