### PR TITLE
Vote-351: Remove Unused Container Element

### DIFF
--- a/layouts/partials/deadlines.html
+++ b/layouts/partials/deadlines.html
@@ -7,9 +7,7 @@
 		<h2>{{ replace $translation.register.dates__heading "%state_name%" .Params.state_name }}</h2>
 	</header>
 {{end}}
-{{ if eq .Params.registration_type "not-needed"}}
-			{{/* Exclude registered-resources content for accessability*/}}
-	{{ else }}
+{{ if ne .Params.registration_type "not-needed"}}
 <ul class="registered-resources">
 	{{ if or (ne .Params.online_deadline nil) (ne .Params.default_online_deadline nil) }}
 		{{ $onlineDeadline := cond (ne .Params.online_deadline nil) (partial "date-format-online.html" .) .Params.default_online_deadline }}

--- a/layouts/partials/deadlines.html
+++ b/layouts/partials/deadlines.html
@@ -7,7 +7,9 @@
 		<h2>{{ replace $translation.register.dates__heading "%state_name%" .Params.state_name }}</h2>
 	</header>
 {{end}}
-
+{{ if eq .Params.registration_type "not-needed"}}
+			{{/* Exclude registered-resources content for accessability*/}}
+	{{ else }}
 <ul class="registered-resources">
 	{{ if or (ne .Params.online_deadline nil) (ne .Params.default_online_deadline nil) }}
 		{{ $onlineDeadline := cond (ne .Params.online_deadline nil) (partial "date-format-online.html" .) .Params.default_online_deadline }}
@@ -39,6 +41,7 @@
 		</li>
 	{{ end }}
 </ul>
+{{ end }}
 
 <!-- To use a different link than the default one for any language use the variable name 'confirm_registration_link_override' in states-data.json for that language -->
 {{ $confirm_registration_link := .Params.confirm_registration_link_override | default .Params.confirm_registration_link }}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-351](https://cm-jira.usa.gov/browse/VOTE-351)

## Description

This PR will help resolve an accessibility error flagged on `North Dakota/Not Needed`.  The error was flagging a div that was not being used. 

Since registration was not needed for this state the text will not be rendered but the div is still present within the DOM. 

For the fix, an if statement was created that if the state was `not needed` then the div would not be rendered and for anything else, it would be 

## Deployment and testing

### Pre-deploy

n/a

### Post-deploy

n/a

### QA/Test

1. visit [preview link](https://cg-9e8debaf-b030-4825-a43c-cb2bc850c96c.sites.pages.cloud.gov/preview/usagov/vote-gov/bug/vote-351-unused-container/register/nd/) and inspect and search for `class="registered-resources"`the expected result is that it will not be present 
2. navigate to another page and search for the same and the expected result is that it will be present 
3. visit several states and ensure there are no visual regression issues
4. also run the following commands `npm run cy:axe` and `npm run cy:test` and ensure tests are passing

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
