### PR TITLE
Vote-352: Remove alt text for footer logo

### DIFF
--- a/data/translations/bn/footer.json
+++ b/data/translations/bn/footer.json
@@ -9,7 +9,6 @@
   "eac_link": "https://www.eac.gov/",
   "eac_text": "এর সাথে অংশীদারিত্বে",
   "eac_logo_alt_text": "মার্কিন নির্বাচন সহায়তা কমিশনের লোগো যা Vote.gov-এর সাথে অংশীদারিত্ব নির্দেশ করে",
-  "vote_logo_alt_text": "চেক করা ব্যালট ঢোকানো হচ্ছে সহ ভোটার বাক্সের চিত্র ভোটিং কার্যক্রম নির্দেশ করে",
   "privacy_policy": "গোপনীয়তা নীতি (ইংরেজিতে)",
   "privacy_policy_link_url": "https://www.usa.gov/policies",
   "twitter_link": "https://twitter.com/votegov",

--- a/data/translations/en/footer.json
+++ b/data/translations/en/footer.json
@@ -13,7 +13,6 @@
   "your_email_address": "Enter your email address",
   "usagov_logo_alt_text": "%USA.gov% logo",
   "eac_logo_alt_text": "U.S. Election Assistance Commission logo which indicates a partnership with Vote.gov",
-  "vote_logo_alt_text": "Illustration of voter box with checked ballot being inserted to indicate voting action",
   "identifier_aria": "Agency identifier",
   "identifier_gsa_txt_aria": "Agency description",
   "identifier_gsa_txt": "An official website of the %link%",

--- a/data/translations/es/footer.json
+++ b/data/translations/es/footer.json
@@ -13,7 +13,6 @@
   "your_email_address": "Ingrese su email",
   "usagov_logo_alt_text": "%USA.gov% en español logo",
   "eac_logo_alt_text": "Logotipo de la Comisión de Asistencia Electoral de EE. UU. para indicar su asociación con Vote.gov.",
-  "vote_logo_alt_text": "Ilustración del acto del voto donde una boleta marcada está siendo insertada en una urna.",
   "about_link": "/es/acerca-de-votegov",
   "accessibility_link": "/es/compromiso-con-la-accesibilidad",
   "sitemap_link": "/es/mapa-del-sitio/",

--- a/data/translations/hi/footer.json
+++ b/data/translations/hi/footer.json
@@ -9,7 +9,6 @@
   "eac_link": "https://www.eac.gov/",
   "eac_text": "के साथ साझेदारी में",
   "eac_logo_alt_text": "अमेरिकी चुनाव सहायता आयोग (यूएस इलेक्शन असिस्टेंस कमीशन) का लोगो जो Vote.gov के साथ साझेदारी का संकेत देता है",
-  "vote_logo_alt_text": "मतदान क्रिया को इंगित करने के लिए मतदाता पेटी में चेक किए गए मतपत्र को डाले जाने का चित्रण",
   "privacy_policy": "गोपनीयता नीति (अंग्रेज़ी में)",
   "privacy_policy_link_url": "https://www.usa.gov/policies",
   "twitter_link": "https://twitter.com/votegov",

--- a/data/translations/km/footer.json
+++ b/data/translations/km/footer.json
@@ -9,7 +9,6 @@
   "eac_link": "https://www.eac.gov/",
   "eac_text": "ក្នុងភាពជាដៃគូជាមួយ",
   "eac_logo_alt_text": "ស្លាកសញ្ញាគណៈកម្មការជំនួយការបោះឆ្នោតសហរដ្ឋអាមេរិក ដែលបង្ហាញពីភាពជាដៃគូជាមួយ Vote.gov",
-  "vote_logo_alt_text": "រូបភាពនៃប្រអប់អ្នកបោះឆ្នោតដែលមានសន្លឹកឆ្នោតបានគូសធីកត្រូវបានបញ្ចូល ដើម្បីបង្ហាញពីសកម្មភាពបោះឆ្នោត",
   "privacy_policy": "គោលការណ៍ឯកជនភាព (ជាភាសាអង់គ្លេស)",
   "privacy_policy_link_url": "https://www.usa.gov/policies",
   "twitter_link": "https://twitter.com/votegov",

--- a/data/translations/ko/footer.json
+++ b/data/translations/ko/footer.json
@@ -9,7 +9,6 @@
   "eac_link": "https://www.eac.gov/",
   "eac_text": "협력 제공 기관",
   "eac_logo_alt_text": "Vote.gov와의 파트너십을 나타내는 미국 선거 지원 위원회의 로고",
-  "vote_logo_alt_text": "표시한 투표 용지를 유권자 투표 상자에 삽입하는 투표 과정을 보여주는 그림",
   "privacy_policy": "개인정보 정책(영어로 제공)",
   "privacy_policy_link_url": "https://www.usa.gov/policies",
   "twitter_link": "https://twitter.com/votegov",

--- a/data/translations/nv/footer.json
+++ b/data/translations/nv/footer.json
@@ -13,7 +13,6 @@
   "your_email_address": "Ni'email hane' nich'8' 1l'8n7gi bik11' 1n7l44h",
   "usagov_logo_alt_text": "%USAGov% na'ashch'22' bee b44h0zin logo woly4h7g77",
   "eac_logo_alt_text": "US Election Assistance Commission bi-logo bik1'7g77 Vote.gov yi[ naazhnish biniy4",
-  "vote_logo_alt_text": "Sitsaa y1zh7 biyi' asdzogo naashch'22'go e'et'11d biih yilts0osgo bik11'",
   "about_link": "/nv/about-us/",
   "sitemap_link": "/nv/sitemap/",
   "identifier_aria": "Da'7n77sh bee 44h0zin7g77",

--- a/data/translations/tl/footer.json
+++ b/data/translations/tl/footer.json
@@ -9,7 +9,6 @@
   "eac_link": "https://www.eac.gov/",
   "eac_text": "sa pakikipagtulungan sa ",
   "eac_logo_alt_text": "Logo ng US Election Assistance Commission na nagsasaad ng pakikipag-partner sa Vote.gov",
-  "vote_logo_alt_text": "Ilustrasyon ng kahon ng botante na may naka-tsek na balota na inilalagay upang ipahiwatig ang aksyon sa pagboto",
   "privacy_policy": "Patakaran sa Privacy (sa Ingles)",
   "privacy_policy_link_url": "https://www.usa.gov/policies",
   "twitter_link": "https://twitter.com/votegov",

--- a/data/translations/vi/footer.json
+++ b/data/translations/vi/footer.json
@@ -9,7 +9,6 @@
   "eac_link": "https://www.eac.gov/",
   "eac_text": "hợp tác với",
   "eac_logo_alt_text": "Huy hiệu của Ủy ban Hỗ trợ Bầu cử Hoa Kỳ cho thấy mối quan hệ đối tác với Vote.gov",
-  "vote_logo_alt_text": "Hình minh họa của ô bỏ phiếu với lá phiếu đã đánh dấu được chèn vào để biểu thị hành động bỏ phiếu",
   "privacy_policy": "Chính sách bảo mật (bằng tiếng Anh) ",
   "privacy_policy_link_url": "https://www.usa.gov/policies",
   "twitter_link": "https://twitter.com/votegov",

--- a/data/translations/ypk/footer.json
+++ b/data/translations/ypk/footer.json
@@ -10,7 +10,6 @@
   "eac_text": "ilalkiilluteng",
   "eac_text__1": "-nkutgun",
   "eac_logo_alt_text": "US-em Kestistengita Kayutangita Qepghaghtengita igaa kelgutkanga ilakullghiit Vote.gov-enkunun",
-  "vote_logo_alt_text": "Teruwiiq nakmikellghem salngaganeng igaq apeghiiqaq kananghtekanga kelgutilghii nakmikilleghmeng. ",
   "privacy_policy": "Aksaqegkam igaa (Laluramkestun)",
   "privacy_policy_link_url": "https://www.usa.gov/policies",
   "twitter_link": "https://twitter.com/votegov",

--- a/data/translations/zh-hans/footer.json
+++ b/data/translations/zh-hans/footer.json
@@ -9,7 +9,6 @@
   "eac_link": "https://www.eac.gov/",
   "eac_text": "与合作",
   "eac_logo_alt_text": "美国选举援助委员会标志，显示与 Vote.gov 的合作关系",
-  "vote_logo_alt_text": "插有已勾选选票的选票箱图样，表示投票动作",
   "privacy_policy": "隐私政策 (英文)",
   "privacy_policy_link_url": "https://www.usa.gov/policies",
   "twitter_link": "https://twitter.com/votegov",

--- a/data/translations/zh/footer.json
+++ b/data/translations/zh/footer.json
@@ -9,7 +9,6 @@
   "eac_link": "https://www.eac.gov/",
   "eac_text": "合作方 ",
   "eac_logo_alt_text": "美國選舉援助委員會標誌，顯示與 Vote.gov 的合作關係",
-  "vote_logo_alt_text": "插有已勾選選票的投票箱圖示，表示投票行為",
   "privacy_policy": "隱私政策（英文）",
   "privacy_policy_link_url": "https://www.usa.gov/policies",
   "twitter_link": "https://twitter.com/votegov",

--- a/layouts/partials/contact-identifier.html
+++ b/layouts/partials/contact-identifier.html
@@ -10,8 +10,7 @@
       <div class="grid-row">
         <div class="tablet:grid-col-auto">
           <div class="vote-txt">Vote.gov</div>
-          <img class="vote-logo" loading="lazy" width="130" height="160" src="{{ .Site.BaseURL }}/assets/img/ballot_box-blue.svg"
-            alt="{{ $translation.footer.vote_logo_alt_text }}" aria-label="Vote.gov">
+          <img class="vote-logo" loading="lazy" width="130" height="160" src="{{ .Site.BaseURL }}/assets/img/ballot_box-blue.svg" role='presentation'>
         </div>
         <div class="tablet:grid-col-auto partnership-txt">{{ $translation.footer.eac_text }}</div>
         <div class="tablet:grid-col-auto eac-container">

--- a/layouts/partials/contact-identifier.html
+++ b/layouts/partials/contact-identifier.html
@@ -10,7 +10,7 @@
       <div class="grid-row">
         <div class="tablet:grid-col-auto">
           <div class="vote-txt">Vote.gov</div>
-          <img class="vote-logo" loading="lazy" width="130" height="160" src="{{ .Site.BaseURL }}/assets/img/ballot_box-blue.svg" role='presentation'>
+          <img class="vote-logo" loading="lazy" width="130" height="160" src="{{ .Site.BaseURL }}/assets/img/ballot_box-blue.svg" alt="" role='presentation'>
         </div>
         <div class="tablet:grid-col-auto partnership-txt">{{ $translation.footer.eac_text }}</div>
         <div class="tablet:grid-col-auto eac-container">


### PR DESCRIPTION
Ticket: [Vote-352](https://cm-jira.usa.gov/browse/VOTE-352)
Purpose: Removing alt text for the footer logo to match work that was done on the CMS.  This is a decorative image and text is not needed. 
Testing:
1. visit [preview link]() and inspect the logo in the footter contact and ensure that alt text is no longer present. 