### PR TITLE
updated branch to check staging and move to v4 for node setup

### DIFF
--- a/.github/workflows/cypress-external-links-cron-workflow.yml
+++ b/.github/workflows/cypress-external-links-cron-workflow.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout code on main.
         uses: actions/checkout@v4
         with: 
-          ref: master
+          ref: staging
 
       - name: Install node.js.
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
 


### PR DESCRIPTION
This Pr will update the cron run for proofer to use the node set up V4.. V3 is getting updated due to node 16 end of life.  I also updated the branch to check staging and not main to help with running more update links that get updated 

![Screenshot 2024-01-25 at 12 02 25 PM](https://github.com/usagov/vote-gov/assets/88721460/3b5f86e6-b070-4b1d-a343-ad05520f02ab)
