### PR TITLE
Vote-854: Update from Code Scanning

### DIFF
--- a/content/en/promoting-access-to-voting.html
+++ b/content/en/promoting-access-to-voting.html
@@ -88,4 +88,4 @@ dismantle misinformation.</li>
     </div>
   </div>
 <br/>
-  <p><a href="{{< assetpath src=`/modernizing-vote_gov-brief.pdf` >}}" target="_blank"><strong>Download a PDF of this page</strong></a></p>
+  <p><a href="{{< assetpath src=`/modernizing-vote_gov-brief.pdf` >}}" target="_blank" rel="noopener noreferrer"><strong>Download a PDF of this page</strong></a></p>

--- a/content/es/promoviendo-acceso-al-voto.html
+++ b/content/es/promoviendo-acceso-al-voto.html
@@ -83,4 +83,4 @@ translationKey = "modernization"
     </div>
   </div>
 <br/>
-<p><a href="{{< assetpath src=`/es/vote_gov-se-moderniza-sinopsis.pdf` >}}" target="_blank"><strong>Descargar un PDF de esta página</strong></a></p>
+<p><a href="{{< assetpath src=`/es/vote_gov-se-moderniza-sinopsis.pdf` >}}" target="_blank" rel="noopener noreferrer"><strong>Descargar un PDF de esta página</strong></a></p>


### PR DESCRIPTION
Ticket: [Vote-854](https://cm-jira.usa.gov/browse/VOTE-854)

Purpose: Updating 2 links that were flagged from code scanning as being unsafe -> https://github.com/usagov/vote-gov/security/code-scanning/1 and https://github.com/usagov/vote-gov/security/code-scanning/2.

The recommended fix was to add the attribute `rel="noopener noreferrer"` to the links.  From what I can tell it was on PDF links, I also did a search for the same type of link and these were the only 2 that were flagged 

Testing:
- Vist `https://vote.gov/promoting-access-to-voting/` and scroll to the bottom and ensure that PDF still opens in a new page